### PR TITLE
Hansen EE Data source update

### DIFF
--- a/gfwanalysis/config/base.py
+++ b/gfwanalysis/config/base.py
@@ -15,7 +15,7 @@ SETTINGS = {
         'service_account': '390573081381-lm51tabsc8q8b33ik497hc66qcmbj11d@developer.gserviceaccount.com',
         'privatekey_file': BASE_DIR + '/privatekey.pem',
         'assets': {
-            'hansen': 'projects/wri-datalab/HansenComposite_14-15',
+            'hansen': 'projects/wri-datalab/HansenComposite_15',
             'forma250GFW': 'projects/wri-datalab/FormaGlobalGFW'
         }
     },


### PR DESCRIPTION
Changing `hansen` EE data source from `projects/wri-datalab/HansenComposite_14-15` to `projects/wri-datalab/HansenComposite_15` in response to basecamp issue https://basecamp.com/3063126/projects/10726176/todos/308550862