### PR TITLE
Forma target data update

### DIFF
--- a/gfwanalysis/config/base.py
+++ b/gfwanalysis/config/base.py
@@ -16,7 +16,7 @@ SETTINGS = {
         'privatekey_file': BASE_DIR + '/privatekey.pem',
         'assets': {
             'hansen': 'projects/wri-datalab/HansenComposite_15',
-            'forma250GFW': 'projects/wri-datalab/FormaGlobalGFW'
+            'forma250GFW': 'projects/wri-datalab/FORMA250'
         }
     },
     'carto': {


### PR DESCRIPTION
Forma data path was broken following a name change on Earth Engine WRI account. This PR points to the new name of the dataset.