### PR TITLE
Add microservice for returning URL of Earth Engine Landsat

### DIFF
--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -15,7 +15,7 @@ from flask import Flask
 from gfwanalysis.config import SETTINGS
 from gfwanalysis.routes.api import error
 from gfwanalysis.routes.api.v1 import hansen_endpoints_v1, forma250_endpoints_v1, \
-    biomass_loss_endpoints_v1
+    biomass_loss_endpoints_v1, landsat_tiles_endpoints_v1
 from gfwanalysis.utils.files import load_config_json
 import CTRegisterMicroserviceFlask
 
@@ -43,6 +43,7 @@ app = Flask(__name__)
 app.register_blueprint(hansen_endpoints_v1, url_prefix='/api/v1/umd-loss-gain')
 app.register_blueprint(forma250_endpoints_v1, url_prefix='/api/v1/forma250gfw')
 app.register_blueprint(biomass_loss_endpoints_v1, url_prefix='/api/v1/biomass-loss')
+app.register_blueprint(landsat_tiles_endpoints_v1, url_prefix='/api/v1/landsat-tiles')
 
 # CT
 info = load_config_json('register')

--- a/gfwanalysis/errors.py
+++ b/gfwanalysis/errors.py
@@ -16,6 +16,8 @@ class Error(Exception):
 class HansenError(Error):
     pass
 
+class LandsatTilesError(Error):
+    pass
 
 class FormaError(Error):
     pass

--- a/gfwanalysis/routes/api/v1/__init__.py
+++ b/gfwanalysis/routes/api/v1/__init__.py
@@ -1,3 +1,4 @@
 from gfwanalysis.routes.api.v1.hansen_router import hansen_endpoints_v1
 from gfwanalysis.routes.api.v1.forma250_router import forma250_endpoints_v1
 from gfwanalysis.routes.api.v1.biomass_loss_router import biomass_loss_endpoints_v1
+from gfwanalysis.routes.api.v1.landsat_router import landsat_tiles_endpoints_v1

--- a/gfwanalysis/routes/api/v1/landsat_router.py
+++ b/gfwanalysis/routes/api/v1/landsat_router.py
@@ -6,8 +6,8 @@ from __future__ import print_function
 
 import logging
 
-from flask import jsonify, request, Blueprint
-from gfwanalysis.routes.api import error, set_params
+from flask import jsonify, Blueprint
+from gfwanalysis.routes.api import error
 from gfwanalysis.services.analysis.landsat_tiles import LandsatTiles
 from gfwanalysis.errors import LandsatTilesError
 from gfwanalysis.serializers import serialize_landsat_url
@@ -17,9 +17,6 @@ landsat_tiles_endpoints_v1 = Blueprint('landsat_tiles_endpoints_v1', __name__)
 
 def analyze(year):
     """Generate Landsat tile url for a requested YEAR"""
-    year = request.get_json().get('year', None)
-    if not year:
-        return error(status=400, detail='Year is required')
     try:
         data = LandsatTiles.analyze(year=year)
     except LandsatTilesError as e:
@@ -31,7 +28,7 @@ def analyze(year):
     return jsonify(data=serialize_landsat_url(data, 'landsat_tiles_url')), 200
 
 
-@landsat_tiles_endpoints_v1.route('/', strict_slashes=False, methods=['GET'])
+@landsat_tiles_endpoints_v1.route('/<year>', strict_slashes=False, methods=['GET'])
 def get_by_geostore(year):
     """Analyze by geostore"""
     logging.info('[ROUTER]: Getting url for tiles for year')

--- a/gfwanalysis/routes/api/v1/landsat_router.py
+++ b/gfwanalysis/routes/api/v1/landsat_router.py
@@ -1,0 +1,38 @@
+"""API ROUTER"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+
+from flask import jsonify, request, Blueprint
+from gfwanalysis.routes.api import error, set_params
+from gfwanalysis.services.analysis.landsat_tiles import LandsatTiles
+from gfwanalysis.errors import LandsatTilesError
+from gfwanalysis.serializers import serialize_landsat_url
+
+landsat_tiles_endpoints_v1 = Blueprint('landsat_tiles_endpoints_v1', __name__)
+
+
+def analyze(year):
+    """Generate Landsat tile url for a requested YEAR"""
+    year = request.get_json().get('year', None)
+    if not year:
+        return error(status=400, detail='Year is required')
+    try:
+        data = LandsatTiles.analyze(year=year)
+    except LandsatTilesError as e:
+        logging.error('[ROUTER]: '+e.message)
+        return error(status=500, detail=e.message)
+    except Exception as e:
+        logging.error('[ROUTER]: '+str(e))
+        return error(status=500, detail='Generic Error')
+    return jsonify(data=serialize_landsat_url(data, 'landsat_tiles_url')), 200
+
+
+@landsat_tiles_endpoints_v1.route('/', strict_slashes=False, methods=['GET'])
+def get_by_geostore(year):
+    """Analyze by geostore"""
+    logging.info('[ROUTER]: Getting url for tiles for year')
+    return analyze(year)

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -27,7 +27,6 @@ def serialize_forma(analysis, type):
         }
     }
 
-
 def serialize_biomass(analysis, type):
     """Convert the output of the biomass_loss analysis to json"""
     return {
@@ -43,3 +42,13 @@ def serialize_biomass(analysis, type):
             'areaHa': analysis.get('area_ha', None)
         }
     }
+
+def serialize_landsat_url(analysis, type):
+    """Convert output of landsat_tiles to json"""
+    return {
+        'id': None,
+        'type': type,
+        'attributes':{
+            "url": analysis.get('url', None)
+            }
+        }

--- a/gfwanalysis/services/analysis/landsat_tiles.py
+++ b/gfwanalysis/services/analysis/landsat_tiles.py
@@ -1,0 +1,60 @@
+"""EE LANDSAT TILE URL SERVICE"""
+
+import logging
+
+import ee
+from gfwanalysis.errors import LandsatTilesError
+from gfwanalysis.config import SETTINGS
+
+
+class LandsatTiles(object):
+    """Create a target url to be used as webmap tiles for Landsat annual data images.
+    Input should be the year of the composited images to create. Note that this is
+    necessary because the URLs from Earth Engine expire every 3 days.
+    """
+
+    @staticmethod
+    def tile_url(image, viz_params=None):
+        """Create a target url for tiles for an image. e.g.:
+        im = ee.Image("LE7_TOA_1YEAR/" + year).select("B3","B2","B1")
+        viz = {'opacity': 1, 'gain':3.5, 'bias':4, 'gamma':1.5}
+        url = tile_url(image=im),viz_params=viz)
+        """
+        if viz_params:
+            d = image.getMapId(viz_params)
+        else:
+            d = image.getMapId()
+        base_url = 'https://earthengine.googleapis.com'
+        url = (base_url + '/map/' + d['mapid'] + '/{z}/{x}/{y}?token=' + d['token'])
+        return url
+
+    @staticmethod
+    def pansharpened_L8_image(year):
+        collection = ee.ImageCollection('LANDSAT/LC8_L1T').filterDate(
+                            "{0}-01-01T00:00".format(year), "{0}-12-31T00:00".format(year))
+        composite = ee.Algorithms.SimpleLandsatComposite(collection=collection,
+                            percentile=50, maxDepth=80, cloudScoreRange=1, asFloat=True)
+        hsv2 = composite.select(['B4', 'B3', 'B2']).rgbToHsv()
+        sharpened = ee.Image.cat([hsv2.select('hue'), hsv2.select('saturation'),
+                            composite.select('B8')]).hsvToRgb().visualize(
+                            gain=1000, gamma= [1.15, 1.4, 1.15])
+        return sharpened
+
+    @staticmethod
+    def analyze(year):
+        """For a given year, generate a valid url from which to retrieve Landsat
+        tiles directly from Earth Engine. This is necessary as the urls expire.
+        Currently, only 2015 and 2016 are supported as input years.
+        """
+        try:
+            d = {}
+            if int(year) in [2015, 2016]:
+                image = pansharpened_L8_image(year)
+                d['url'] = tile_url(image)
+            else:
+                logging.warning("Bad: URL for tiles for year={0} requested".format(year))
+                d['url'] = None
+            return d
+        except Exception as error:
+            logging.error(str(error))
+            raise LandsatTilesError(message='Landsat Tile URL creation Error')

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -99,11 +99,11 @@
 			"path": "/api/v1/biomass-loss/use/:name/:id"
 		}
     },{
-			"path": "/v1/landsat-tiles/:year",
+		"path": "/v1/landsat-tiles/:year",
+		"method": "GET",
+		"redirect": {
 			"method": "GET",
-			"redirect": {
-				"method": "GET",
-				"path": "/api/v1/landsat-tiles/:year"
-			}
-			}]
+			"path": "/api/v1/landsat-tiles/:year"
+		}
+	}]
 }

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -98,5 +98,12 @@
 			"method": "GET",
 			"path": "/api/v1/biomass-loss/use/:name/:id"
 		}
-    }]
+    },{
+			"path": "/v1/landsat-tiles/:year",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/landsat-tiles/:year"
+			}
+			}]
 }


### PR DESCRIPTION
* Added /v1/landsat-tiles/:year endpoint (where year is either 2015 or 2016)
* Returns JSON object, with url for temporarily authorised Earth Engine tiles