### PR TITLE
New High-res Imagery Service

### DIFF
--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -16,7 +16,7 @@ from gfwanalysis.config import SETTINGS
 from gfwanalysis.routes.api import error
 from gfwanalysis.routes.api.v1 import hansen_endpoints_v1, forma250_endpoints_v1, \
     biomass_loss_endpoints_v1, landsat_tiles_endpoints_v1, histogram_endpoints_v1, \
-    landcover_endpoints_v1, sentinel_tiles_endpoints_v1
+    landcover_endpoints_v1, sentinel_tiles_endpoints_v1, highres_tiles_endpoints_v1
 from gfwanalysis.utils.files import load_config_json
 import CTRegisterMicroserviceFlask
 
@@ -46,6 +46,7 @@ app.register_blueprint(forma250_endpoints_v1, url_prefix='/api/v1/forma250gfw')
 app.register_blueprint(biomass_loss_endpoints_v1, url_prefix='/api/v1/biomass-loss')
 app.register_blueprint(landsat_tiles_endpoints_v1, url_prefix='/api/v1/landsat-tiles')
 app.register_blueprint(sentinel_tiles_endpoints_v1, url_prefix='/api/v1/sentinel-tiles')
+app.register_blueprint(highres_tiles_endpoints_v1, url_prefix='/api/v1/highres-tiles')
 app.register_blueprint(histogram_endpoints_v1, url_prefix='/api/v1/loss-by-landcover')
 app.register_blueprint(landcover_endpoints_v1, url_prefix='/api/v1/landcover')
 

--- a/gfwanalysis/errors.py
+++ b/gfwanalysis/errors.py
@@ -28,6 +28,8 @@ class LandsatTilesError(Error):
 class SentinelTilesError(Error):
     pass
 
+class HighResTilesError(Error):
+    pass
 
 class FormaError(Error):
     pass

--- a/gfwanalysis/middleware.py
+++ b/gfwanalysis/middleware.py
@@ -25,6 +25,24 @@ def get_sentinel_params(func):
         return func(*args, **kwargs)
     return wrapper
 
+def get_highres_params(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        if request.method == 'GET':
+            lat = request.args.get('lat')
+            lon = request.args.get('lon')
+            start = request.args.get('start')
+            end = request.args.get('end')
+            if not lat or not lon or not start or not end:
+                return error(status=400, detail='Some parameters are needed')
+        kwargs["lat"] = lat
+        kwargs["lon"] = lon
+        kwargs["start"] = start
+        kwargs["end"] = end
+        return func(*args, **kwargs)
+    return wrapper
+
 
 def get_geo_by_hash(func):
     """Get geodata"""

--- a/gfwanalysis/routes/api/v1/__init__.py
+++ b/gfwanalysis/routes/api/v1/__init__.py
@@ -3,5 +3,6 @@ from gfwanalysis.routes.api.v1.forma250_router import forma250_endpoints_v1
 from gfwanalysis.routes.api.v1.biomass_loss_router import biomass_loss_endpoints_v1
 from gfwanalysis.routes.api.v1.landsat_router import landsat_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.sentinel_router import sentinel_tiles_endpoints_v1
+from gfwanalysis.routes.api.v1.highres_router import highres_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.histogram_router import histogram_endpoints_v1
 from gfwanalysis.routes.api.v1.landcover_router import landcover_endpoints_v1

--- a/gfwanalysis/routes/api/v1/highres_router.py
+++ b/gfwanalysis/routes/api/v1/highres_router.py
@@ -1,0 +1,45 @@
+"""API ROUTER"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+
+from flask import jsonify, Blueprint
+from gfwanalysis.routes.api import error
+from gfwanalysis.services.analysis.highres_tiles import HighResTiles
+from gfwanalysis.errors import HighResTilesError
+from gfwanalysis.serializers import serialize_highres_url
+from gfwanalysis.middleware import get_highres_params
+
+highres_tiles_endpoints_v1 = Blueprint('highres_tiles_endpoints_v1', __name__) 
+
+def analyze2(lat, lon, start, end):
+    """Generate Sentinel tile url for a requested lat lon point and time prd
+    #Example of valid inputs (for area focused on Tenerife)
+    lat = -16.589
+    lon = 28.246
+    start ='2017-03-01'
+    end ='2017-03-10'
+    """
+    logging.info("[ANALYSIS] function initiated")
+
+    try:
+        data = HighResTiles.proxy_highres(lat=lat, lon=lon,
+                                            start=start, end=end)
+    except HighResTilesError as e:
+        logging.error('[ROUTER]: '+e.message)
+        return error(status=500, detail=e.message)
+    except Exception as e:
+        logging.error('[ROUTER]: '+str(e))
+        return error(status=500, detail='Generic Error')
+    return jsonify(data=serialize_highres_url(data, 'highres_tiles_url')), 200
+
+
+@highres_tiles_endpoints_v1.route('/', strict_slashes=False, methods=['GET'])
+@get_highres_params
+def get_by_geostore(lat, lon, start, end):
+    """Analyze by geostore"""
+    logging.info('[ROUTER]: Getting url(s) for tiles for Sentinel')
+    return analyze2(lat=lat, lon=lon, start=start, end=end)

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -1,4 +1,5 @@
 """Serializers"""
+import logging
 
 
 def serialize_umd(analysis, type):
@@ -90,3 +91,26 @@ def serialize_sentinel_url(analysis, type):
             "product_id": analysis.get('metadata', None).get('product_id', None),
             }
         }
+
+##### CHECK THIS. For loop for element retrieval.
+def serialize_highres_url(analysis, type):
+    """Convert output of images to json"""
+    output = []
+
+    for e in range (0, len(analysis)):
+        temp_output = {
+            'id': None,
+            'type': type,
+            'attributes':{
+                'source': analysis[e].get('metadata', None).get('source', None),
+                'cloud_score': analysis[e].get('metadata', None).get('cloud_score', None),
+                'date_time': analysis[e].get('metadata', None).get('date_time', None),
+                'metadata': analysis[e].get('metadata', None),
+                'tile_url': analysis[e].get('tile_url', None),
+                'thumbnail_url': analysis[e].get('thumbnail_url', None),
+                'boundary_tiles': analysis[e].get('boundary_tiles', None)
+            }
+        }
+        output.append(temp_output)
+
+    return output

--- a/gfwanalysis/services/analysis/highres_tiles.py
+++ b/gfwanalysis/services/analysis/highres_tiles.py
@@ -1,0 +1,104 @@
+"""EE SENTINEL TILE URL SERVICE"""
+
+import logging
+
+import ee
+from gfwanalysis.errors import LandsatTilesError
+from gfwanalysis.config import SETTINGS
+
+
+class HighResTiles(object):
+    """Create dictionary with two urls to be used as webmap tiles for Sentinel 2
+    data. One should be the tile outline, and the other is the RGB data visulised.
+    Metadata should also be returned, containing cloud score etc.
+    Note that the URLs from Earth Engine expire every 3 days.
+    """
+
+    @staticmethod
+    def tile_url2(image, viz_params=None):
+        logging.info("[TILE_URL] function initiated")
+        """Create a target url for tiles for an image.
+        """
+        if viz_params:
+            d = image.getMapId(viz_params)
+            logging.info(d)
+        else:
+            d = image.getMapId()
+        base_url = 'https://earthengine.googleapis.com'
+        url = (base_url + '/map/' + d['mapid'] + '/{z}/{x}/{y}?token=' + d['token'])
+        logging.info(url)
+        return url
+
+    @staticmethod
+    def proxy_highres(lat, lon, start, end):
+        """
+        Sentinel covers all continental land surfaces (including inland waters) between latitudes 56° south and 83° north
+            all coastal waters up to 20 km from the shore
+            all islands greater than 100 km2
+            all EU islands
+            the Mediterranean Sea
+            all closed seas (e.g. Caspian Sea).
+
+        This will return a JSON object of n elements, with each element containing an image url, thumbnail url, boundary tiles
+        (and related metadata) for each Sentinel image taken  at (lat, lon) within the time range (start - end).
+
+        Note the url generated expires after a few days and needs to be refreshed.
+        e.g. variables
+        lat = -16.66
+        lon = 28.24
+        start = '2017-01-01'
+        end = '2017-03-01'
+        """
+        logging.info("[HIGH RES] function initiated")
+
+        try:            
+            point = ee.Geometry.Point(float(lat), float(lon))
+            S2 = ee.ImageCollection('COPERNICUS/S2').filterDate(start,end).filterBounds(point)
+            S2_list = S2.toList(S2.size().getInfo())
+
+            output = []
+
+            for x in range (0, S2.size().getInfo()):
+
+                d = S2_list.getInfo()[x] ##access asset id 
+                S2 = ee.Image(d.get('id'))
+                S2 = S2.divide(10000)  # Convert to Top of the atmosphere reflectance
+                S2 = S2.visualize(bands=["B4", "B3", "B2"], min=0, max=0.3, opacity=1.0)
+
+                image_tiles = HighResTiles.tile_url2(S2)
+                thumbnail = S2.getThumbURL({'dimensions':[250,250]})
+
+                boundary = ee.Feature(ee.Geometry.LinearRing(d.get('properties').get("system:footprint").get('coordinates')))
+                boundary_tiles = HighResTiles.tile_url2(boundary, {'color': '4eff32'})
+
+                meta = HighResTiles.get_image_metadata2(d)
+
+                temp_output = {
+                        
+                    'boundary_tiles': boundary_tiles,
+                    'tile_url': image_tiles,
+                    'thumbnail_url': thumbnail,
+                    'metadata': meta,
+                    'success': True
+                
+                }
+
+                output.append(temp_output)
+            return output
+
+        except:
+            raise ValueError('High Res service failed to return image.')
+
+    @staticmethod
+    def get_image_metadata2(d):
+        """Return a dictionary of metadata"""
+        image_name = d.get('id')
+        source = d["properties"]['SPACECRAFT_NAME']
+        cloud_score = d["properties"]['CLOUDY_PIXEL_PERCENTAGE']
+        date_info = image_name.split('COPERNICUS/S2/')[1]
+        date_time = ''.join([date_info[0:4],'-',date_info[4:6],'-',date_info[6:8],' ',
+                        date_info[9:11],':',date_info[11:13],':',date_info[13:15],"Z"])
+        product_id = d.get('properties').get('PRODUCT_ID')
+        meta = {}
+        meta = {'source': source, 'image_name': image_name, 'cloud_score': cloud_score, 'date_time': date_time, 'product_id': product_id}
+        return meta

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -154,5 +154,12 @@
 			"method": "GET",
 			"path": "/api/v1/sentinel-tiles/"
 		}
+		},{
+			"path": "/v1/highres-tiles/",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/highres-tiles/"
+			}
 	}]
 }


### PR DESCRIPTION
Adds a new microservice that fetches Sentinel2 images & related metadata:

1. /v1/highres-tiles endpoint
2. Fetches all tiles from Earth Engine that intersect with a user defined lat/lon and fall between a pair of start and end dates
3. Returns a JSON object of n elements each containing: *image and thumbnail urls, metadata, boundary*
