### PR TITLE
Extended UMD service to return tree cover extent 2010

### DIFF
--- a/gfwanalysis/config/base.py
+++ b/gfwanalysis/config/base.py
@@ -16,6 +16,7 @@ SETTINGS = {
         'privatekey_file': BASE_DIR + '/privatekey.pem',
         'assets': {
             'hansen': 'projects/wri-datalab/HansenComposite_16',
+            'hansen_2010_extent': 'projects/wri-datalab/HansenTreeCover2010',
             'globcover': 'ESA/GLOBCOVER_L4_200901_200912_V2_3',
             'foraf': 'projects/wri-datalab/gfw-api/central-africa_veg_foraf',
             'liberia': 'projects/wri-datalab/gfw-api/lbr-landcover',

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -11,6 +11,7 @@ def serialize_umd(analysis, type):
             'loss': analysis.get('loss', None),
             'gain': analysis.get('gain', None),
             'treeExtent': analysis.get('tree_extent', None),
+            'treeExtent2010': analysis.get('tree_extent2010', None),
             'areaHa': analysis.get('area_ha', None),
         }
     }

--- a/gfwanalysis/services/analysis/hansen_service.py
+++ b/gfwanalysis/services/analysis/hansen_service.py
@@ -33,6 +33,7 @@ class HansenService(object):
         try:
             d = {}
             asset_id = SETTINGS.get('gee').get('assets').get('hansen')
+            extent_2010_asset = SETTINGS.get('gee').get('assets').get('hansen_2010_extent')
             begin = int(begin.split('-')[0][2:])
             end = int(end.split('-')[0][2:])
             region = get_region(geojson)
@@ -47,6 +48,11 @@ class HansenService(object):
             tree_area = gfw_data.select(cover_band).gt(0).multiply(
                             ee.Image.pixelArea()).reduceRegion(**reduce_args).getInfo()
             d['tree_extent'] = squaremeters_to_ha(tree_area[cover_band])
+            # Identify 2010 forest cover at given threshold
+            extent2010_image = ee.Image(extent_2010_asset)
+            extent2010_area = extent2010_image.gt(float(threshold)).multiply(
+                                ee.Image.pixelArea()).reduceRegion(**reduce_args).getInfo()
+            d['tree_extent2010'] = squaremeters_to_ha(extent2010_area['b1'])
             # Identify tree gain over data collection period
             gain = gfw_data.select('gain').divide(255.0).multiply(
                             ee.Image.pixelArea()).reduceRegion(**reduce_args).getInfo()


### PR DESCRIPTION
New Hansen 2010 data for thresholded tree cover extent is now returned from the UMD analysis too, e.g.:

```
https://production-api.globalforestwatch.org/v1/umd-loss-gain?geostore=f0c23f8b880ad794b52c1f8e8a8e394f&period=2001-01-01%2C2016-12-31&thresh=30&_=1515770363838


{"data":{"attributes":{"areaHa":5267243.828294489,
"gain":3998.66,
"loss":104933.04,
"treeExtent":5214577.76,
"treeExtent2010":XXXX},
"id":null,"type":"umd"}}

```