### PR TITLE
Feature: Add fast 'Recent Images' Microservice

### DIFF
--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -53,17 +53,17 @@ app.register_blueprint(histogram_endpoints_v1, url_prefix='/api/v1/loss-by-landc
 app.register_blueprint(landcover_endpoints_v1, url_prefix='/api/v1/landcover')
 
 # CT
-info = load_config_json('register')
-swagger = load_config_json('swagger')
-CTRegisterMicroserviceFlask.register(
-    app=app,
-    name='gfw-umd',
-    info=info,
-    swagger=swagger,
-    mode=CTRegisterMicroserviceFlask.AUTOREGISTER_MODE if os.getenv('CT_REGISTER_MODE') and os.getenv('CT_REGISTER_MODE') == 'auto' else CTRegisterMicroserviceFlask.NORMAL_MODE,
-    ct_url=os.getenv('CT_URL'),
-    url=os.getenv('LOCAL_URL')
-)
+# info = load_config_json('register')
+# swagger = load_config_json('swagger')
+# CTRegisterMicroserviceFlask.register(
+#     app=app,
+#     name='gfw-umd',
+#     info=info,
+#     swagger=swagger,
+#     mode=CTRegisterMicroserviceFlask.AUTOREGISTER_MODE if os.getenv('CT_REGISTER_MODE') and os.getenv('CT_REGISTER_MODE') == 'auto' else CTRegisterMicroserviceFlask.NORMAL_MODE,
+#     ct_url=os.getenv('CT_URL'),
+#     url=os.getenv('LOCAL_URL')
+# )
 
 
 @app.errorhandler(403)

--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -16,7 +16,8 @@ from gfwanalysis.config import SETTINGS
 from gfwanalysis.routes.api import error
 from gfwanalysis.routes.api.v1 import hansen_endpoints_v1, forma250_endpoints_v1, \
     biomass_loss_endpoints_v1, landsat_tiles_endpoints_v1, histogram_endpoints_v1, \
-    landcover_endpoints_v1, sentinel_tiles_endpoints_v1, highres_tiles_endpoints_v1
+    landcover_endpoints_v1, sentinel_tiles_endpoints_v1, highres_tiles_endpoints_v1, \
+    recent_tiles_endpoints_v1
 from gfwanalysis.utils.files import load_config_json
 import CTRegisterMicroserviceFlask
 
@@ -47,6 +48,7 @@ app.register_blueprint(biomass_loss_endpoints_v1, url_prefix='/api/v1/biomass-lo
 app.register_blueprint(landsat_tiles_endpoints_v1, url_prefix='/api/v1/landsat-tiles')
 app.register_blueprint(sentinel_tiles_endpoints_v1, url_prefix='/api/v1/sentinel-tiles')
 app.register_blueprint(highres_tiles_endpoints_v1, url_prefix='/api/v1/highres-tiles')
+app.register_blueprint(recent_tiles_endpoints_v1, url_prefix='/api/v1/recent-tiles')
 app.register_blueprint(histogram_endpoints_v1, url_prefix='/api/v1/loss-by-landcover')
 app.register_blueprint(landcover_endpoints_v1, url_prefix='/api/v1/landcover')
 

--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -53,17 +53,17 @@ app.register_blueprint(histogram_endpoints_v1, url_prefix='/api/v1/loss-by-landc
 app.register_blueprint(landcover_endpoints_v1, url_prefix='/api/v1/landcover')
 
 # CT
-# info = load_config_json('register')
-# swagger = load_config_json('swagger')
-# CTRegisterMicroserviceFlask.register(
-#     app=app,
-#     name='gfw-umd',
-#     info=info,
-#     swagger=swagger,
-#     mode=CTRegisterMicroserviceFlask.AUTOREGISTER_MODE if os.getenv('CT_REGISTER_MODE') and os.getenv('CT_REGISTER_MODE') == 'auto' else CTRegisterMicroserviceFlask.NORMAL_MODE,
-#     ct_url=os.getenv('CT_URL'),
-#     url=os.getenv('LOCAL_URL')
-# )
+info = load_config_json('register')
+swagger = load_config_json('swagger')
+CTRegisterMicroserviceFlask.register(
+    app=app,
+    name='gfw-umd',
+    info=info,
+    swagger=swagger,
+    mode=CTRegisterMicroserviceFlask.AUTOREGISTER_MODE if os.getenv('CT_REGISTER_MODE') and os.getenv('CT_REGISTER_MODE') == 'auto' else CTRegisterMicroserviceFlask.NORMAL_MODE,
+    ct_url=os.getenv('CT_URL'),
+    url=os.getenv('LOCAL_URL')
+)
 
 @app.errorhandler(403)
 def forbidden(e):

--- a/gfwanalysis/errors.py
+++ b/gfwanalysis/errors.py
@@ -31,6 +31,9 @@ class SentinelTilesError(Error):
 class HighResTilesError(Error):
     pass
 
+class RecentTilesError(Error):
+    pass
+
 class FormaError(Error):
     pass
 

--- a/gfwanalysis/middleware.py
+++ b/gfwanalysis/middleware.py
@@ -53,7 +53,7 @@ def get_recent_params(func):
             start = request.args.get('start')
             end = request.args.get('end')
             if not lat or not lon or not start or not end:
-                return error(status=400, detail='Some parameters are needed')
+                return error(status=400, detail='[RECENT] Some parameters are needed')
         kwargs["lat"] = lat
         kwargs["lon"] = lon
         kwargs["start"] = start
@@ -66,16 +66,11 @@ def get_recent_tiles(func):
     def wrapper(*args, **kwargs):
 
         if request.method == 'GET':
-            lat = request.args.get('lat')
-            lon = request.args.get('lon')
-            start = request.args.get('start')
-            end = request.args.get('end')
-            if not lat or not lon or not start or not end:
-                return error(status=400, detail='Some parameters are needed')
-        kwargs["lat"] = lat
-        kwargs["lon"] = lon
-        kwargs["start"] = start
-        kwargs["end"] = end
+            data_array = request.args.get('data_array')
+            if not data_array:
+                return error(status=400, detail='[TILES] Some parameters are needed')
+        kwargs["data_array"] = data_array
+
         return func(*args, **kwargs)
     return wrapper
 
@@ -84,16 +79,11 @@ def get_recent_thumbs(func):
     def wrapper(*args, **kwargs):
 
         if request.method == 'GET':
-            lat = request.args.get('lat')
-            lon = request.args.get('lon')
-            start = request.args.get('start')
-            end = request.args.get('end')
-            if not lat or not lon or not start or not end:
-                return error(status=400, detail='Some parameters are needed')
-        kwargs["lat"] = lat
-        kwargs["lon"] = lon
-        kwargs["start"] = start
-        kwargs["end"] = end
+            data_array = request.args.get('data_array')
+            if not data_array:
+                return error(status=400, detail='[THUMBS] Some parameters are needed')
+        kwargs["data_array"] = data_array
+
         return func(*args, **kwargs)
     return wrapper
 

--- a/gfwanalysis/middleware.py
+++ b/gfwanalysis/middleware.py
@@ -43,6 +43,59 @@ def get_highres_params(func):
         return func(*args, **kwargs)
     return wrapper
 
+def get_recent_params(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        if request.method == 'GET':
+            lat = request.args.get('lat')
+            lon = request.args.get('lon')
+            start = request.args.get('start')
+            end = request.args.get('end')
+            if not lat or not lon or not start or not end:
+                return error(status=400, detail='Some parameters are needed')
+        kwargs["lat"] = lat
+        kwargs["lon"] = lon
+        kwargs["start"] = start
+        kwargs["end"] = end
+        return func(*args, **kwargs)
+    return wrapper
+
+def get_recent_tiles(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        if request.method == 'GET':
+            lat = request.args.get('lat')
+            lon = request.args.get('lon')
+            start = request.args.get('start')
+            end = request.args.get('end')
+            if not lat or not lon or not start or not end:
+                return error(status=400, detail='Some parameters are needed')
+        kwargs["lat"] = lat
+        kwargs["lon"] = lon
+        kwargs["start"] = start
+        kwargs["end"] = end
+        return func(*args, **kwargs)
+    return wrapper
+
+def get_recent_thumbs(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        if request.method == 'GET':
+            lat = request.args.get('lat')
+            lon = request.args.get('lon')
+            start = request.args.get('start')
+            end = request.args.get('end')
+            if not lat or not lon or not start or not end:
+                return error(status=400, detail='Some parameters are needed')
+        kwargs["lat"] = lat
+        kwargs["lon"] = lon
+        kwargs["start"] = start
+        kwargs["end"] = end
+        return func(*args, **kwargs)
+    return wrapper
 
 def get_geo_by_hash(func):
     """Get geodata"""

--- a/gfwanalysis/middleware.py
+++ b/gfwanalysis/middleware.py
@@ -2,6 +2,7 @@
 
 from functools import wraps
 from flask import request
+import logging
 
 from gfwanalysis.routes.api import error
 from gfwanalysis.services.geostore_service import GeostoreService
@@ -65,8 +66,8 @@ def get_recent_tiles(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
 
-        if request.method == 'GET':
-            data_array = request.args.get('data_array')
+        if request.method == 'POST':
+            data_array = request.get_json().get('source_data')
             if not data_array:
                 return error(status=400, detail='[TILES] Some parameters are needed')
         kwargs["data_array"] = data_array
@@ -78,8 +79,8 @@ def get_recent_thumbs(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
 
-        if request.method == 'GET':
-            data_array = request.args.get('data_array')
+        if request.method == 'POST':
+            data_array = request.get_json().get('source_data')
             if not data_array:
                 return error(status=400, detail='[THUMBS] Some parameters are needed')
         kwargs["data_array"] = data_array

--- a/gfwanalysis/routes/api/v1/__init__.py
+++ b/gfwanalysis/routes/api/v1/__init__.py
@@ -4,5 +4,6 @@ from gfwanalysis.routes.api.v1.biomass_loss_router import biomass_loss_endpoints
 from gfwanalysis.routes.api.v1.landsat_router import landsat_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.sentinel_router import sentinel_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.highres_router import highres_tiles_endpoints_v1
+from gfwanalysis.routes.api.v1.recent_router import recent_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.histogram_router import histogram_endpoints_v1
 from gfwanalysis.routes.api.v1.landcover_router import landcover_endpoints_v1

--- a/gfwanalysis/routes/api/v1/recent_router.py
+++ b/gfwanalysis/routes/api/v1/recent_router.py
@@ -1,0 +1,118 @@
+"""API ROUTER"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import asyncio
+import requests
+import functools as funct
+
+from flask import jsonify, Blueprint
+from gfwanalysis.routes.api import error
+from gfwanalysis.services.analysis.recent_tiles import RecentTiles
+from gfwanalysis.errors import RecentTilesError
+from gfwanalysis.serializers import serialize_recent_url
+from gfwanalysis.middleware import get_recent_params
+from gfwanalysis.middleware import get_recent_tiles
+from gfwanalysis.middleware import get_recent_thumbs
+
+recent_tiles_endpoints_v1 = Blueprint('recent_tiles_endpoints_v1', __name__) 
+
+def analyze_recent_data(lat, lon, start, end):
+    """Returns metadata and *first* tile url from GEE for all Sentinel images
+       in date range ('start'-'end') that intersect with lat,lon.
+    #Example of valid inputs (for area focused on Tenerife)
+    lat = -16.589
+    lon = 28.246
+    start ='2017-03-01'
+    end ='2017-03-10'
+    """
+    logging.info("[ANALYSIS>DATA] function initiated")
+    
+    try:
+        data = RecentTiles.recent_data(lat=lat, lon=lon, start=start, end=end)
+        data = RecentTiles.async_fetch(RecentTiles.recent_tiles, data)
+        data = RecentTiles.async_fetch(RecentTiles.recent_thumbs, data)
+        logging.info("[ANALYSIS>DATA] Complete!")
+    except RecentTilesError as e:
+        logging.error('[ROUTER]: '+e.message)
+        return error(status=500, detail=e.message)
+    except Exception as e:
+        logging.error('[ROUTER]: '+str(e))
+        return error(status=500, detail='Generic Error')
+    return jsonify(data=serialize_recent_url(data, 'recent_tiles_url')), 200
+
+def analyze_recent_tiles(lat, lon, start, end):
+    """Returns metadata and *first* tile url from GEE for all Sentinel images
+       in date range ('start'-'end') that intersect with lat,lon.
+    #Example of valid inputs (for area focused on Tenerife)
+    lat = -16.589
+    lon = 28.246
+    start ='2017-03-01'
+    end ='2017-03-10'
+    """
+    logging.info("[ANALYSIS>TILES] function initiated")
+    
+    try:
+        data = RecentTiles.recent_data(lat=lat, lon=lon, start=start, end=end)
+        data = RecentTiles.async_fetch(RecentTiles.recent_tiles, data)
+        logging.info("[ANALYSIS>DATA] Complete!")
+    except RecentTilesError as e:
+        logging.error('[ROUTER]: '+e.message)
+        return error(status=500, detail=e.message)
+    except Exception as e:
+        logging.error('[ROUTER]: '+str(e))
+        return error(status=500, detail='Generic Error')
+    return jsonify(data=serialize_recent_url(data, 'recent_tiles_url')), 200
+
+def analyze_recent_thumbs(lat, lon, start, end):
+    """Returns metadata and *first* tile url from GEE for all Sentinel images
+       in date range ('start'-'end') that intersect with lat,lon.
+    #Example of valid inputs (for area focused on Tenerife)
+    lat = -16.589
+    lon = 28.246
+    start ='2017-03-01'
+    end ='2017-03-10'
+    """
+    logging.info("[ANALYSIS>THUMBS] function initiated")
+    
+    try:
+        data = RecentTiles.recent_data(lat=lat, lon=lon, start=start, end=end)
+        data = RecentTiles.async_fetch(RecentTiles.recent_thumbs, data)
+        logging.info("[ANALYSIS>DATA] Complete!")
+    except RecentTilesError as e:
+        logging.error('[ROUTER]: '+e.message)
+        return error(status=500, detail=e.message)
+    except Exception as e:
+        logging.error('[ROUTER]: '+str(e))
+        return error(status=500, detail='Generic Error')
+    return jsonify(data=serialize_recent_url(data, 'recent_tiles_url')), 200
+
+@recent_tiles_endpoints_v1.route('/', strict_slashes=False, methods=['GET'])
+@get_recent_params
+def get_by_geostore(lat, lon, start, end):
+
+    """Analyze by geostore"""
+    logging.info('[ROUTER]: Getting url(s) for tiles for Recent Sentinel Images')
+    data = analyze_recent_data(lat=lat, lon=lon, start=start, end=end)   
+    return data
+
+@recent_tiles_endpoints_v1.route('/tiles', strict_slashes=False, methods=['GET'])
+@get_recent_tiles
+def get_by_tile(lat, lon, start, end):
+
+    """Analyze by geostore"""
+    logging.info('[ROUTER]: Getting url(s) for tiles for Recent Sentinel Images')
+    data = analyze_recent_tiles(lat=lat, lon=lon, start=start, end=end)   
+    return data
+
+@recent_tiles_endpoints_v1.route('/thumbs', strict_slashes=False, methods=['GET'])
+@get_recent_thumbs
+def get_by_thumb(lat, lon, start, end):
+
+    """Analyze by geostore"""
+    logging.info('[ROUTER]: Getting url(s) for tiles for Recent Sentinel Images')
+    data = analyze_recent_thumbs(lat=lat, lon=lon, start=start, end=end)   
+    return data

--- a/gfwanalysis/routes/api/v1/recent_router.py
+++ b/gfwanalysis/routes/api/v1/recent_router.py
@@ -17,7 +17,8 @@ from gfwanalysis.serializers import serialize_recent_url
 from gfwanalysis.serializers import serialize_recent_data
 from gfwanalysis.middleware import get_recent_params, get_recent_tiles, get_recent_thumbs
 
-recent_tiles_endpoints_v1 = Blueprint('recent_tiles_endpoints_v1', __name__) 
+recent_tiles_endpoints_v1 = Blueprint('recent_tiles_endpoints_v1', __name__)
+
 
 def analyze_recent_data(lat, lon, start, end):
     """Returns metadata and *first* tile url from GEE for all Sentinel images
@@ -28,9 +29,8 @@ def analyze_recent_data(lat, lon, start, end):
     start ='2017-03-01'
     end ='2017-03-10'
     """
-
     loop = asyncio.new_event_loop()
-    
+
     try:
         #Get data
         data = RecentTiles.recent_data(lat=lat, lon=lon, start=start, end=end)
@@ -44,13 +44,14 @@ def analyze_recent_data(lat, lon, start, end):
         return error(status=500, detail='Generic Error')
     return jsonify(data=serialize_recent_data(data, 'recent_tiles_data')), 200
 
+
 def analyze_recent_tiles(data_array):
-    """Takes an array of JSON objects with a 'source' key for each tile url 
+    """Takes an array of JSON objects with a 'source' key for each tile url
     to be returned. Returns an array of 'source' names and 'tile_url' values.
     """
 
     loop = asyncio.new_event_loop()
-    
+
     try:
         data = loop.run_until_complete(RecentTiles.async_fetch(loop, RecentTiles.recent_tiles, data_array))
     except RecentTilesError as e:
@@ -61,15 +62,14 @@ def analyze_recent_tiles(data_array):
         return error(status=500, detail='Generic Error')
     return jsonify(data=serialize_recent_url(data, 'recent_tiles_url')), 200
 
+
 def analyze_recent_thumbs(data_array):
-    """Takes an array of JSON objects with a 'source' key for each tile url 
+    """Takes an array of JSON objects with a 'source' key for each tile url
     to be returned. Returns an array of 'source' names and 'thumb_url' values.
     """
-
     loop = asyncio.new_event_loop()
-     
     try:
-        data = loop.run_until_complete(RecentTiles.async_fetch(loop,RecentTiles.recent_thumbs, data_array))
+        data = loop.run_until_complete(RecentTiles.async_fetch(loop, RecentTiles.recent_thumbs, data_array))
     except RecentTilesError as e:
         logging.error('[ROUTER]: '+e.message)
         return error(status=500, detail=e.message)
@@ -78,29 +78,29 @@ def analyze_recent_thumbs(data_array):
         return error(status=500, detail='Generic Error')
     return jsonify(data=serialize_recent_url(data, 'recent_thumbs_url')), 200
 
+
 @recent_tiles_endpoints_v1.route('/', strict_slashes=False, methods=['GET'])
 @get_recent_params
 def get_by_geostore(lat, lon, start, end):
-
     """Analyze by geostore"""
     logging.info('[ROUTER]: Getting data for tiles for Recent Sentinel Images')
-    data = analyze_recent_data(lat=lat, lon=lon, start=start, end=end)   
+    data = analyze_recent_data(lat=lat, lon=lon, start=start, end=end)
     return data
+
 
 @recent_tiles_endpoints_v1.route('/tiles', strict_slashes=False, methods=['POST'])
 @get_recent_tiles
 def get_by_tile(data_array):
     """Analyze by geostore"""
     logging.info('[ROUTER]: Getting tile url(s) for tiles for Recent Sentinel Images')
-    logging.debug(request.get_json())
-    data = analyze_recent_tiles(data_array=data_array)   
+    data = analyze_recent_tiles(data_array=data_array)
     return data
+
 
 @recent_tiles_endpoints_v1.route('/thumbs', strict_slashes=False, methods=['POST'])
 @get_recent_thumbs
 def get_by_thumb(data_array):
-
     """Analyze by geostore"""
     logging.info('[ROUTER]: Getting thumb url(s) for tiles for Recent Sentinel Images')
-    data = analyze_recent_thumbs(data_array=data_array)   
+    data = analyze_recent_thumbs(data_array=data_array)
     return data

--- a/gfwanalysis/routes/api/v1/recent_router.py
+++ b/gfwanalysis/routes/api/v1/recent_router.py
@@ -14,6 +14,7 @@ from gfwanalysis.routes.api import error
 from gfwanalysis.services.analysis.recent_tiles import RecentTiles
 from gfwanalysis.errors import RecentTilesError
 from gfwanalysis.serializers import serialize_recent_url
+from gfwanalysis.serializers import serialize_recent_data
 from gfwanalysis.middleware import get_recent_params
 from gfwanalysis.middleware import get_recent_tiles
 from gfwanalysis.middleware import get_recent_thumbs
@@ -31,10 +32,15 @@ def analyze_recent_data(lat, lon, start, end):
     """
     logging.info("[ANALYSIS>DATA] function initiated")
     
+    loop = asyncio.new_event_loop()
+    logging.info("[ANALYSIS>LOOP] loop initiated")
+    
     try:
+        #Get data
         data = RecentTiles.recent_data(lat=lat, lon=lon, start=start, end=end)
-        data = RecentTiles.async_fetch(RecentTiles.recent_tiles, data)
-        data = RecentTiles.async_fetch(RecentTiles.recent_thumbs, data)
+        #Get first tile
+        data = loop.run_until_complete(RecentTiles.async_fetch(loop, RecentTiles.recent_tiles, data, 'first'))
+
         logging.info("[ANALYSIS>DATA] Complete!")
     except RecentTilesError as e:
         logging.error('[ROUTER]: '+e.message)
@@ -42,22 +48,20 @@ def analyze_recent_data(lat, lon, start, end):
     except Exception as e:
         logging.error('[ROUTER]: '+str(e))
         return error(status=500, detail='Generic Error')
-    return jsonify(data=serialize_recent_url(data, 'recent_tiles_url')), 200
+    return jsonify(data=serialize_recent_data(data, 'recent_tiles_data')), 200
 
-def analyze_recent_tiles(lat, lon, start, end):
-    """Returns metadata and *first* tile url from GEE for all Sentinel images
-       in date range ('start'-'end') that intersect with lat,lon.
-    #Example of valid inputs (for area focused on Tenerife)
-    lat = -16.589
-    lon = 28.246
-    start ='2017-03-01'
-    end ='2017-03-10'
+def analyze_recent_tiles(data_array):
+    """Takes an array of JSON objects with a 'source' key for each tile url 
+    to be returned. Returns an array of 'source' names and 'tile_url' values.
     """
     logging.info("[ANALYSIS>TILES] function initiated")
+    # data_array = data_array.get('data_array')
+
+    loop = asyncio.new_event_loop()
+    logging.info("[ANALYSIS>LOOP] loop initiated")
     
     try:
-        data = RecentTiles.recent_data(lat=lat, lon=lon, start=start, end=end)
-        data = RecentTiles.async_fetch(RecentTiles.recent_tiles, data)
+        data = loop.run_until_complete(RecentTiles.async_fetch(loop, RecentTiles.recent_tiles, data_array))
         logging.info("[ANALYSIS>DATA] Complete!")
     except RecentTilesError as e:
         logging.error('[ROUTER]: '+e.message)
@@ -67,20 +71,18 @@ def analyze_recent_tiles(lat, lon, start, end):
         return error(status=500, detail='Generic Error')
     return jsonify(data=serialize_recent_url(data, 'recent_tiles_url')), 200
 
-def analyze_recent_thumbs(lat, lon, start, end):
-    """Returns metadata and *first* tile url from GEE for all Sentinel images
-       in date range ('start'-'end') that intersect with lat,lon.
-    #Example of valid inputs (for area focused on Tenerife)
-    lat = -16.589
-    lon = 28.246
-    start ='2017-03-01'
-    end ='2017-03-10'
+def analyze_recent_thumbs(data_array):
+    """Takes an array of JSON objects with a 'source' key for each tile url 
+    to be returned. Returns an array of 'source' names and 'thumb_url' values.
     """
-    logging.info("[ANALYSIS>THUMBS] function initiated")
+    logging.info("[ANALYSIS>TILES] function initiated")
+    # data_array = data_array.get('data_array')
+
+    loop = asyncio.new_event_loop()
+    logging.info("[ANALYSIS>LOOP] loop initiated")
     
     try:
-        data = RecentTiles.recent_data(lat=lat, lon=lon, start=start, end=end)
-        data = RecentTiles.async_fetch(RecentTiles.recent_thumbs, data)
+        data = loop.run_until_complete(RecentTiles.async_fetch(loop,RecentTiles.recent_thumbs, data_array))
         logging.info("[ANALYSIS>DATA] Complete!")
     except RecentTilesError as e:
         logging.error('[ROUTER]: '+e.message)
@@ -88,7 +90,7 @@ def analyze_recent_thumbs(lat, lon, start, end):
     except Exception as e:
         logging.error('[ROUTER]: '+str(e))
         return error(status=500, detail='Generic Error')
-    return jsonify(data=serialize_recent_url(data, 'recent_tiles_url')), 200
+    return jsonify(data=serialize_recent_url(data, 'recent_thumbs_url')), 200
 
 @recent_tiles_endpoints_v1.route('/', strict_slashes=False, methods=['GET'])
 @get_recent_params
@@ -101,18 +103,18 @@ def get_by_geostore(lat, lon, start, end):
 
 @recent_tiles_endpoints_v1.route('/tiles', strict_slashes=False, methods=['GET'])
 @get_recent_tiles
-def get_by_tile(lat, lon, start, end):
+def get_by_tile(data_array):
 
     """Analyze by geostore"""
     logging.info('[ROUTER]: Getting url(s) for tiles for Recent Sentinel Images')
-    data = analyze_recent_tiles(lat=lat, lon=lon, start=start, end=end)   
+    data = analyze_recent_tiles(data_array)   
     return data
 
 @recent_tiles_endpoints_v1.route('/thumbs', strict_slashes=False, methods=['GET'])
 @get_recent_thumbs
-def get_by_thumb(lat, lon, start, end):
+def get_by_thumb(data_array):
 
     """Analyze by geostore"""
     logging.info('[ROUTER]: Getting url(s) for tiles for Recent Sentinel Images')
-    data = analyze_recent_thumbs(lat=lat, lon=lon, start=start, end=end)   
+    data = analyze_recent_thumbs(data_array=data_array)   
     return data

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -115,7 +115,7 @@ def serialize_highres_url(analysis, type):
 
     return output
 
-def serialize_recent_url(analysis, type):
+def serialize_recent_data(analysis, type):
     logging.info("[SERIALISER] initiating...")
     """Convert output of images to json"""
     output = []
@@ -125,12 +125,46 @@ def serialize_recent_url(analysis, type):
             'id': None,
             'type': type,
             'attributes':{
-                'source': analysis[e].get('id', None),
+                'spacecraft': analysis[e].get('spacecraft', None),
+                'source': analysis[e].get('source', None),
                 'cloud_score': analysis[e].get('cloud_score', None),
                 'date_time': analysis[e].get('date', None),
                 'tile_url': analysis[e].get('tile_url', None),
                 'thumbnail_url': analysis[e].get('thumb_url', None),
                 'boundary_tiles': analysis[e].get('boundary', None)
+            }
+        }
+        output.append(temp_output)
+    logging.info("[SERIALISER] Complete!")
+    return output
+
+def serialize_recent_url(analysis, type):
+    logging.info("[SERIALISER] initiating...")
+    """Convert output of images to json"""
+    output = []
+    
+    if type == 'recent_thumbs_url':
+        
+        for e in range (0, len(analysis)):
+            temp_output = {
+                'id': None,
+                'type': type,
+                'attributes':{
+                    'source': analysis[e].get('source', None),
+                    'thumbnail_url': analysis[e].get('thumb_url', None)
+            }
+        }
+        output.append(temp_output)
+        
+    elif type == 'recent_tiles_url':
+
+        for e in range (0, len(analysis)):
+            temp_output = {
+                'id': None,
+                'type': type,
+                'attributes':{
+                    'source': analysis[e].get('source', None),
+                    'tile_url': analysis[e].get('tile_url', None)
             }
         }
         output.append(temp_output)

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -125,48 +125,48 @@ def serialize_recent_data(analysis, type):
             'id': None,
             'type': type,
             'attributes':{
-                'spacecraft': analysis[e].get('spacecraft', None),
+                'instrument': analysis[e].get('spacecraft', None),
                 'source': analysis[e].get('source', None),
                 'cloud_score': analysis[e].get('cloud_score', None),
                 'date_time': analysis[e].get('date', None),
                 'tile_url': analysis[e].get('tile_url', None),
                 'thumbnail_url': analysis[e].get('thumb_url', None),
-                'boundary_tiles': analysis[e].get('boundary', None)
+                'boundary_url': analysis[e].get('boundary', None)
             }
         }
         output.append(temp_output)
-    logging.info("[SERIALISER] Complete!")
     return output
 
 def serialize_recent_url(analysis, type):
-    logging.info("[SERIALISER] initiating...")
+    logging.info("[SERIALISER] Initiating")
     """Convert output of images to json"""
-    output = []
+    tmp_output = []
+    output = {}
     
     if type == 'recent_thumbs_url':
+
+        output['id'] = None
+        output['type'] = type
         
         for e in range (0, len(analysis)):
-            temp_output = {
-                'id': None,
-                'type': type,
-                'attributes':{
+            temp_obj = {
                     'source': analysis[e].get('source', None),
                     'thumbnail_url': analysis[e].get('thumb_url', None)
             }
-        }
-        output.append(temp_output)
+            tmp_output.append(temp_obj)
+        output['attributes'] = tmp_output
         
     elif type == 'recent_tiles_url':
 
+        output['id'] = None
+        output['type'] = type
+
         for e in range (0, len(analysis)):
-            temp_output = {
-                'id': None,
-                'type': type,
-                'attributes':{
-                    'source': analysis[e].get('source', None),
+            temp_obj = {
+                    'source_id': analysis[e].get('source', None),
                     'tile_url': analysis[e].get('tile_url', None)
             }
-        }
-        output.append(temp_output)
-    logging.info("[SERIALISER] Complete!")
+            tmp_output.append(temp_obj)            
+        output['attributes'] = tmp_output
+
     return output

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -114,3 +114,25 @@ def serialize_highres_url(analysis, type):
         output.append(temp_output)
 
     return output
+
+def serialize_recent_url(analysis, type):
+    logging.info("[SERIALISER] initiating...")
+    """Convert output of images to json"""
+    output = []
+
+    for e in range (0, len(analysis)):
+        temp_output = {
+            'id': None,
+            'type': type,
+            'attributes':{
+                'source': analysis[e].get('id', None),
+                'cloud_score': analysis[e].get('cloud_score', None),
+                'date_time': analysis[e].get('date', None),
+                'tile_url': analysis[e].get('tile_url', None),
+                'thumbnail_url': analysis[e].get('thumb_url', None),
+                'boundary_tiles': analysis[e].get('boundary', None)
+            }
+        }
+        output.append(temp_output)
+    logging.info("[SERIALISER] Complete!")
+    return output

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -1,0 +1,183 @@
+"""EE SENTINEL TILE URL SERVICE"""
+
+import logging
+import asyncio
+import requests
+import functools as funct
+
+import ee
+from gfwanalysis.errors import LandsatTilesError
+from gfwanalysis.config import SETTINGS
+
+
+class RecentTiles(object):
+    """Create dictionary with two urls to be used as webmap tiles for Sentinel 2
+    data. One should be the tile outline, and the other is the RGB data visulised.
+    Metadata should also be returned, containing cloud score etc.
+    Note that the URLs from Earth Engine expire every 3 days.
+    """
+
+    # # @staticmethod
+    # async def async_fetch(f, data_array, fetch_type=None):
+    #     logging.info("[RECENT>ASYNC_FETCH] function initiated")
+    #     """Takes collection data array and implements batch fetches
+    #     """
+    #     if fetch_type == 'first':
+    #         r1 = 0
+    #         r2 = 1
+            
+    #     elif fetch_type == 'rest':
+    #         r1 = 1
+    #         r2 = len(data_array)
+            
+    #     else:
+    #         r1 = 0
+    #         r2 = len(data_array)
+            
+    #     futures = [
+    #         loop.run_in_executor(
+    #             None, 
+    #             funct.partial(f, data_array[i]), 
+    #         )
+    #         for i in range(r1,r2)
+    #     ]
+    #     for response in await asyncio.gather(*futures):
+    #         pass
+
+
+    # @staticmethod
+    # def recent_tiles(col_data, viz_params=None):
+    #     logging.info("[RECENT>TILE] function initiated")
+    #     """Takes collection data array and fetches tiles
+    #     """
+
+    #     im = ee.Image(col_data['id']).divide(10000).visualize(bands=["B4", "B3", "B2"], min=0, max=0.3, opacity=1.0)
+        
+    #     if viz_params:
+    #         m_id = im.getMapId(viz_params)
+    #         logging.info(m_id)
+    #     else:
+    #         m_id = im.getMapId()
+
+    #     base_url = 'https://earthengine.googleapis.com'
+    #     url = (base_url + '/map/' + m_id['mapid'] + '/{z}/{x}/{y}?token=' + m_id['token'])
+    #     logging.info(url)
+
+    #     col_data['tile_url'] = url
+
+    #     # return col_data ???
+
+    ###TEST: http://localhost:9000/v1/recent-tiles?lat=-16.644&lon=28.266&start=2017-01-01&end=2017-02-01
+
+    @staticmethod
+    def async_fetch(f, data_array, fetch_type=None):
+        logging.info("[RECENT>ASYNC_FETCH] function initiated")
+        """Takes collection data array and implements batch fetches
+        """
+        
+        if fetch_type == 'first':
+            r1 = 0
+            r2 = 1
+            
+        elif fetch_type == 'rest':
+            r1 = 1
+            r2 = len(data_array)
+            
+        else:
+            r1 = 0
+            r2 = len(data_array)
+ 
+        for i in range(r1,r2):
+            f(data_array[i])
+
+        
+        return data_array
+
+
+    @staticmethod
+    def recent_tiles(col_data, viz_params=None):
+        logging.info("[RECENT>TILE] function initiated")
+        """Takes collection data array and fetches tiles
+        """
+
+        im = ee.Image(col_data['id']).divide(10000).visualize(bands=["B4", "B3", "B2"], min=0, max=0.3, opacity=1.0)
+        
+        if viz_params:
+            m_id = im.getMapId(viz_params)
+            logging.info(m_id)
+        else:
+            m_id = im.getMapId()
+
+        base_url = 'https://earthengine.googleapis.com'
+        url = (base_url + '/map/' + m_id['mapid'] + '/{z}/{x}/{y}?token=' + m_id['token'])
+        logging.info(url)
+
+        col_data['tile_url'] = url
+
+        return col_data
+
+    @staticmethod
+    def recent_thumbs(col_data):
+        logging.info("[RECENT>THUMB] function initiated")
+        """Takes collection data array and fetches thumbs
+        """
+
+        im = ee.Image(col_data['id']).divide(10000).visualize(bands=["B4", "B3", "B2"], min=0, max=0.3, opacity=1.0)
+
+        m_id = im.getMapId()
+
+        thumbnail = im.getThumbURL({'dimensions':[250,250]})
+        logging.info(thumbnail)
+
+        col_data['thumb_url'] = thumbnail
+ 
+        return col_data
+
+    @staticmethod
+    def recent_data(lat, lon, start, end):
+
+        # logging.info("[RECENT] initiating loop")
+        # loop = asyncio.get_event_loop()
+
+        logging.info("[RECENT>DATA] function initiated")
+
+        try:            
+            point = ee.Geometry.Point(float(lat), float(lon))
+            S2 = ee.ImageCollection('COPERNICUS/S2').filterDate(start,end).filterBounds(point).sort('CLOUD_PIXEL_PERCENTAGE',True)
+
+            collection = S2.toList(30).getInfo()
+            data = []
+
+            #Get boundary data (same for every tile)
+            boundary_tile = ee.Feature(ee.Geometry.LinearRing(collection[0]['properties']['system:footprint']['coordinates']))
+
+            b_id = boundary_tile.getMapId({'color': '4eff32'})
+            base_url = 'https://earthengine.googleapis.com'
+            boundary_url = (base_url + '/map/' + b_id['mapid'] + '/{z}/{x}/{y}?token=' + b_id['token'])
+
+            for c in collection:
+
+                date_info = c['id'].split('COPERNICUS/S2/')[1]
+                date_time = ''.join([date_info[0:4],'-',date_info[4:6],'-',date_info[6:8],' ',
+                            date_info[9:11],':',date_info[11:13],':',date_info[13:15],"Z"])
+
+                tmp_ = {
+
+                    'id': c['id'],
+                    'cloud_score': c['properties']['CLOUDY_PIXEL_PERCENTAGE'],
+                    'boundary': boundary_url,
+                    'source': c['properties']['SPACECRAFT_NAME'],
+                    'product_id': c['properties']['PRODUCT_ID'],
+                    'date': date_time
+
+                }
+                data.append(tmp_)
+
+            #Get first tile
+            # loop.run_until_complete(async_fetch(recent_tiles, data, 'first'))
+            
+            return data
+
+        except:
+            raise ValueError('Recent Images service failed to return image.')
+

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -6,7 +6,7 @@ import requests
 import functools as funct
 
 import ee
-from gfwanalysis.errors import LandsatTilesError
+from gfwanalysis.errors import RecentTilesError
 from gfwanalysis.config import SETTINGS
 
 
@@ -17,7 +17,7 @@ class RecentTiles(object):
     Note that the URLs from Earth Engine expire every 3 days.
     """
 
-    ###TEST: http://localhost:9000/v1/recent-tiles?lat=-16.644&lon=28.266&start=2017-01-01&end=2017-02-01
+    ### TEST: http://localhost:9000/v1/recent-tiles?lat=-16.644&lon=28.266&start=2017-01-01&end=2017-02-01
 
     @staticmethod
     async def async_fetch(loop, f, data_array, fetch_type=None):
@@ -36,21 +36,21 @@ class RecentTiles(object):
         else:
             r1 = 0
             r2 = len(data_array)
-        
+
         # Set up list of futures (promises)
         futures = [
             loop.run_in_executor(
-                None, 
-                funct.partial(f, data_array[i]), 
+                None,
+                funct.partial(f, data_array[i]),
             )
-            for i in range(r1,r2)
+            for i in range(r1, r2)
         ]
-        # Fulfill promises 
+        # Fulfill promises
         for response in await asyncio.gather(*futures):
             pass
 
         return_results = []
-        for f in range(0,len(futures)):
+        for f in range(0, len(futures)):
             data_array[f] = futures[f].result()
 
         return data_array
@@ -96,7 +96,7 @@ class RecentTiles(object):
 
         logging.info("[RECENT>DATA] function initiated")
 
-        try:            
+        try:
             point = ee.Geometry.Point(float(lat), float(lon))
             S2 = ee.ImageCollection('COPERNICUS/S2').filterDate(start,end).filterBounds(point).sort('CLOUD_PIXEL_PERCENTAGE',True)
 
@@ -131,5 +131,4 @@ class RecentTiles(object):
             return data
 
         except:
-            raise ValueError('Recent Images service failed to return image.')
-
+            raise RecentTilesError('Recent Images service failed to return image.')

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -21,7 +21,6 @@ class RecentTiles(object):
 
     @staticmethod
     async def async_fetch(loop, f, data_array, fetch_type=None):
-        logging.info("[RECENT>ASYNC_FETCH] function initiated")
         """Takes collection data array and implements batch fetches
         """
         asyncio.set_event_loop(loop)
@@ -50,11 +49,14 @@ class RecentTiles(object):
         for response in await asyncio.gather(*futures):
             pass
 
+        return_results = []
+        for f in range(0,len(futures)):
+            data_array[f] = futures[f].result()
+
         return data_array
 
     @staticmethod
     def recent_tiles(col_data, viz_params=None):
-        logging.info("[RECENT>TILE] function initiated")
         """Takes collection data array and fetches tiles
         """
         logging.info(f"[RECENT>TILE] {col_data}")
@@ -68,7 +70,6 @@ class RecentTiles(object):
 
         base_url = 'https://earthengine.googleapis.com'
         url = (base_url + '/map/' + m_id['mapid'] + '/{z}/{x}/{y}?token=' + m_id['token'])
-        logging.info(url)
 
         col_data['tile_url'] = url
 
@@ -76,7 +77,6 @@ class RecentTiles(object):
 
     @staticmethod
     def recent_thumbs(col_data):
-        logging.info("[RECENT>THUMB] function initiated")
         """Takes collection data array and fetches thumbs
         """
 

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -98,7 +98,7 @@ class RecentTiles(object):
 
         try:
             point = ee.Geometry.Point(float(lat), float(lon))
-            S2 = ee.ImageCollection('COPERNICUS/S2').filterDate(start,end).filterBounds(point).sort('CLOUD_PIXEL_PERCENTAGE',True)
+            S2 = ee.ImageCollection('COPERNICUS/S2').filterDate(start,end).filterBounds(point).sort('CLOUDY_PIXEL_PERCENTAGE',True)
 
             collection = S2.toList(30).getInfo()
             data = []

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -163,16 +163,16 @@
 			}
 	},{
 		"path": "/v1/recent-tiles/tiles",
-		"method": "GET",
+		"method": "POST",
 		"redirect": {
-			"method": "GET",
+			"method": "POST",
 			"path": "/api/v1/recent-tiles/tiles"
 		}
 	},{
 		"path": "/v1/recent-tiles/thumbs",
-		"method": "GET",
+		"method": "POST",
 		"redirect": {
-			"method": "GET",
+			"method": "POST",
 			"path": "/api/v1/recent-tiles/thumbs"
 		}
 	}]

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -155,11 +155,25 @@
 			"path": "/api/v1/sentinel-tiles/"
 		}
 		},{
-			"path": "/v1/highres-tiles/",
+			"path": "/v1/recent-tiles/",
 			"method": "GET",
 			"redirect": {
 				"method": "GET",
-				"path": "/api/v1/highres-tiles/"
+				"path": "/api/v1/recent-tiles/"
 			}
+	},{
+		"path": "/v1/recent-tiles/tiles",
+		"method": "GET",
+		"redirect": {
+			"method": "GET",
+			"path": "/api/v1/recent-tiles/tiles"
+		}
+	},{
+		"path": "/v1/recent-tiles/thumbs",
+		"method": "GET",
+		"redirect": {
+			"method": "GET",
+			"path": "/api/v1/recent-tiles/thumbs"
+		}
 	}]
 }


### PR DESCRIPTION
# Overview

This microservice builds upon the previous 'Sentinel Tiles' microservice and adds a new set of endpoints to asynchronously request multiple tile or thumb urls for added *speed*!

# Endpoints

**/v1/recent-tiles**
Requests image data from GEE for any images taken at a spatial position (lat,long) within a given date range (start, end)

- e.g. params= {'lat':'-16.644', 'lon':'28.266', 'start':'2016-01-01', 'end': "2016-01-08"}

and returns a list of JSON in the following format:

```json
    {
        "attributes": {
        "boundary_url": "https://earthengine.googleapis.com/map/4b1b...",
        "instrument": 'Sentinel-2A',
        "cloud_score": 13.1214,
        "date_time": "2017-01-31 11:52:11Z",
        "source": "COPERNICUS/S2/20170131T115211_20170131T115306_T28RCS",
        "thumbnail_url": Null,
        "tile_url": Null
        },
        "id": Null,
        "type": "recent_tiles_url"
    }
```

**/v1/recent-tiles/tiles**
Requests image tile urls for each source in the returned list. A POST request must be used, sending a payload formatted as follows:

```json
{'source_data':   [{ "source": "COPERNICUS/S2/20170131T11..."},
                   { "source": "COPERNICUS/S2/20170131T12..." }, 
                   ...
                   ]}
```

and returns the corresponding tile url for each source in the list:

```json
    [{"source": "COPERNICUS/S2/20170131T11...",
       "tile_url": "https://earthengine.googleapis.com/api/thumb?thumbid=..."
        },{
       "source": "COPERNICUS/S2/20170131T12...",
       "tile_url": "https://earthengine.googleapis.com/api/thumb?thumbid=..."
        },   ...   {
        "source": "COPERNICUS/S2/20170131T1N...",
        "tile_url": "https://earthengine.googleapis.com/api/thumb?thumbid=..."
        }]
```

**/v1/recent-tiles/thumbs**
Another POST request as above, requiring the same format payload, but instead returning a list containing "thumbnail_url" values for each "source".