### PR TITLE
Updates recent-tiles response

### DIFF
--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -132,7 +132,8 @@ def serialize_recent_data(analysis, type):
                 'date_time': analysis[e].get('date', None),
                 'tile_url': analysis[e].get('tile_url', None),
                 'thumbnail_url': analysis[e].get('thumb_url', None),
-                'boundary_url': analysis[e].get('boundary', None)
+                'boundary_url': analysis[e].get('boundary', None),
+                'bbox': analysis[e].get('bbox', None)
             }
         }
         output.append(temp_output)

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -116,11 +116,19 @@ class RecentTiles(object):
                 date_time = ''.join([date_info[0:4],'-',date_info[4:6],'-',date_info[6:8],' ',
                             date_info[9:11],':',date_info[11:13],':',date_info[13:15],"Z"])
 
+                bbox = c['properties']['system:footprint']['coordinates']
+
                 tmp_ = {
 
                     'source': c['id'],
                     'cloud_score': c['properties']['CLOUDY_PIXEL_PERCENTAGE'],
                     'boundary': boundary_url,
+                    'bbox': {
+                            "geometry": {
+                            "type": "Polygon",
+                            "coordinates": bbox
+                            }
+                          },
                     'spacecraft': c['properties']['SPACECRAFT_NAME'],
                     'product_id': c['properties']['PRODUCT_ID'],
                     'date': date_time


### PR DESCRIPTION
A quick update to include a 'bbox' value in the api response so that it can be utilised in the front-end of GFW.

Response now returns something like:

```
{'data': [{'attributes': {'bbox': {'geometry': {'coordinates': [[-15.92558389724579,
                                                                 28.925190549257714],
                                                                [-15.92559671449868,
                                                                 28.925191163600214],
                                                                [-17.051433713664156,
                                                                 28.91274387174152]],
                                                'type': 'Polygon'}},
                          'boundary_url': '...',
                          'cloud_score': 41.0,
                          'date_time': '2016-01-07 11:54:14Z',
                          'instrument': 'Sentinel-2A',
                          'source': 'COPERNICUS/S2/20160107T115414_20160108T134003_T28RCS',
                          'thumbnail_url': None,
                          'tile_url': '...'},
           'id': None,
           'type': 'recent_tiles_data'}]}
``` 