### PR TITLE
Adds false colour bands argument to recent-tiles GET and POST requests

### DIFF
--- a/gfwanalysis/middleware.py
+++ b/gfwanalysis/middleware.py
@@ -2,7 +2,6 @@
 
 from functools import wraps
 from flask import request
-import logging
 
 from gfwanalysis.routes.api import error
 from gfwanalysis.services.geostore_service import GeostoreService
@@ -54,12 +53,14 @@ def get_recent_params(func):
             lon = request.args.get('lon')
             start = request.args.get('start')
             end = request.args.get('end')
+            bands = request.args.get('bands', None)
             if not lat or not lon or not start or not end:
-                return error(status=400, detail='[RECENT] Some parameters are needed')
+                return error(status=400, detail='[RECENT] Parameters: (lat, lon. start, end) are needed')
         kwargs["lat"] = lat
         kwargs["lon"] = lon
         kwargs["start"] = start
         kwargs["end"] = end
+        kwargs["bands"] = bands
         return func(*args, **kwargs)
     return wrapper
 
@@ -69,9 +70,11 @@ def get_recent_tiles(func):
 
         if request.method == 'POST':
             data_array = request.get_json().get('source_data')
+            bands = request.get_json().get('bands', None)
             if not data_array:
                 return error(status=400, detail='[TILES] Some parameters are needed')
         kwargs["data_array"] = data_array
+        kwargs["bands"] = bands
 
         return func(*args, **kwargs)
     return wrapper
@@ -82,9 +85,11 @@ def get_recent_thumbs(func):
 
         if request.method == 'POST':
             data_array = request.get_json().get('source_data')
+            bands = request.get_json().get('bands', None)
             if not data_array:
                 return error(status=400, detail='[THUMBS] Some parameters are needed')
         kwargs["data_array"] = data_array
+        kwargs["bands"] = bands
 
         return func(*args, **kwargs)
     return wrapper

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -32,11 +32,15 @@ class RecentTiles(object):
         
         parsed_bands = [ b.upper() if b.upper() in SENTINEL_BANDS else None for b in bands ]
 
+        # Check for dupes
+        seen = set()
+        uniq = [b for b in bands if b not in seen and not seen.add(b)]  
+
         #Validate bands
-        if(len(parsed_bands) != 3):
-            raise RecentTilesError('Incorrect number of bands. Must contain 3 elements in the format: [r,b,g].')
+        if(len(parsed_bands) != 3 or len(uniq) != 3):
+            raise RecentTilesError('Must contain 3 unique elements in the format: [r,b,g].')
         elif(None in parsed_bands):
-            raise RecentTilesError('One or more bands do not exist.')
+            raise RecentTilesError('One or more bands are invalid.')
         else:
             return parsed_bands
             


### PR DESCRIPTION
The recent-tiles endpoint is now capable of accepting a `bands` argument, which assigns any arbitrary triplet of sentinel bands to the *rgb* channels to generate a false colour image!

e.g. `http://localhost:4500/api/v1/recent-tiles?lat=-16.644&lon=28.266&start=2017-01-01&end=2017-02-01&bands=[B11,B8A,B2]`

This also applies to the `recent-tiles/tiles` and `recent-tiles/thumbs` endpoints. If no bands are passed, the service will default to 'natural colour' (`bands = [B4, B3, B2]`).

**Note** that the `bands` argument must:

- be a string or array type in the payload json
- contain no duplicates (e.g. )
- contain exactly 3 bands
- must contain bands available in the sentinel service (`'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8A', 'B9', 'B10', 'B11', 'B12'`)