### PR TITLE
added WHRC biomass with Hansen thresholding service

### DIFF
--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -17,7 +17,7 @@ from gfwanalysis.routes.api import error
 from gfwanalysis.routes.api.v1 import hansen_endpoints_v1, forma250_endpoints_v1, \
     biomass_loss_endpoints_v1, landsat_tiles_endpoints_v1, histogram_endpoints_v1, \
     landcover_endpoints_v1, sentinel_tiles_endpoints_v1, highres_tiles_endpoints_v1, \
-    recent_tiles_endpoints_v1
+    recent_tiles_endpoints_v1, whrc_biomass_endpoints_v1
 from gfwanalysis.utils.files import load_config_json
 import CTRegisterMicroserviceFlask
 
@@ -52,6 +52,7 @@ app.register_blueprint(highres_tiles_endpoints_v1, url_prefix='/api/v1/highres-t
 app.register_blueprint(recent_tiles_endpoints_v1, url_prefix='/api/v1/recent-tiles')
 app.register_blueprint(histogram_endpoints_v1, url_prefix='/api/v1/loss-by-landcover')
 app.register_blueprint(landcover_endpoints_v1, url_prefix='/api/v1/landcover')
+app.register_blueprint(whrc_biomass_endpoints_v1, url_prefix='/api/v1/whrc-biomass')
 
 # CT
 info = load_config_json('register')

--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -44,6 +44,7 @@ app = Flask(__name__)
 # Routing
 app.register_blueprint(hansen_endpoints_v1, url_prefix='/api/v1/umd-loss-gain')
 app.register_blueprint(forma250_endpoints_v1, url_prefix='/api/v1/forma250gfw')
+app.register_blueprint(hansen_endpoints_v1, url_prefix='/api/v1/whrc-biomass')
 app.register_blueprint(biomass_loss_endpoints_v1, url_prefix='/api/v1/biomass-loss')
 app.register_blueprint(landsat_tiles_endpoints_v1, url_prefix='/api/v1/landsat-tiles')
 app.register_blueprint(sentinel_tiles_endpoints_v1, url_prefix='/api/v1/sentinel-tiles')

--- a/gfwanalysis/config/base.py
+++ b/gfwanalysis/config/base.py
@@ -27,6 +27,7 @@ SETTINGS = {
             'idn-landcover': 'projects/wri-datalab/gfw-api/idn-landcover',
             'sea-landcover': 'projects/wri-datalab/gfw-api/sea-landcover',
             'forma250GFW': 'projects/wri-datalab/FORMA250',
+            'whrc_biomass':'projects/wri-datalab/WHRC_CARBON',
             'biomassloss': {
                 'hansen_loss_thresh': 'HANSEN/gfw_loss_by_year_threshold_2015',
                 'biomass_2000': 'users/davethau/whrc_carbon_test/carbon'

--- a/gfwanalysis/errors.py
+++ b/gfwanalysis/errors.py
@@ -37,6 +37,8 @@ class RecentTilesError(Error):
 class FormaError(Error):
     pass
 
+class WHRCBiomassError(Error):
+    pass
 
 class BiomassLossError(Error):
     pass

--- a/gfwanalysis/routes/api/v1/__init__.py
+++ b/gfwanalysis/routes/api/v1/__init__.py
@@ -7,3 +7,4 @@ from gfwanalysis.routes.api.v1.highres_router import highres_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.recent_router import recent_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.histogram_router import histogram_endpoints_v1
 from gfwanalysis.routes.api.v1.landcover_router import landcover_endpoints_v1
+from gfwanalysis.routes.api.v1.whrc_biomass_router import whrc_biomass_endpoints_v1

--- a/gfwanalysis/routes/api/v1/whrc_biomass_router.py
+++ b/gfwanalysis/routes/api/v1/whrc_biomass_router.py
@@ -1,0 +1,91 @@
+"""API ROUTER"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+
+from flask import jsonify, request, Blueprint
+from gfwanalysis.routes.api import error, set_params
+from gfwanalysis.services.analysis.whrc_biomass_service import WHRCBiomassService
+from gfwanalysis.validators import validate_geostore
+from gfwanalysis.middleware import get_geo_by_hash, get_geo_by_use, get_geo_by_wdpa, \
+    get_geo_by_national, get_geo_by_subnational, get_geo_by_regional
+from gfwanalysis.errors import WHRCBiomassError
+from gfwanalysis.serializers import serialize_whrc_biomass
+
+whrc_biomass_endpoints_v1 = Blueprint('whrc_biomass', __name__)
+
+
+def analyze(geojson, area_ha):
+    """Analyze WHRC Biomass"""
+    logging.info('[ROUTER]: Getting biomassloss')
+    if not geojson:
+        return error(status=400, detail='Geojson is required')
+
+    threshold, begin, end = set_params()
+
+    try:
+        data = WHRCBiomassService.analyze(
+            geojson=geojson,
+            threshold=threshold,
+            begin=begin,
+            end=end)
+    except BiomassLossError as e:
+        logging.error('[ROUTER]: '+e.message)
+        return error(status=500, detail=e.message)
+    except Exception as e:
+        logging.error('[ROUTER]: '+str(e))
+        return error(status=500, detail='Generic Error')
+
+    data['area_ha'] = area_ha
+    return jsonify(data=serialize_biomass(data, 'biomasses')), 200
+
+
+@whrc_biomass_endpoints_v1.route('/', strict_slashes=False, methods=['GET', 'POST'])
+@validate_geostore
+@get_geo_by_hash
+def get_by_geostore(geojson, area_ha):
+    """By Geostore Endpoint"""
+    logging.info('[ROUTER]: Getting biomassloss by geostore')
+    return analyze(geojson, area_ha)
+
+
+@whrc_biomass_endpoints_v1.route('/use/<name>/<id>', strict_slashes=False, methods=['GET'])
+@get_geo_by_use
+def get_by_use(name, id, geojson, area_ha):
+    """Use Endpoint"""
+    logging.info('[ROUTER]: Getting biomassloss by use')
+    return analyze(geojson, area_ha)
+
+
+@whrc_biomass_endpoints_v1.route('/wdpa/<id>', strict_slashes=False, methods=['GET'])
+@get_geo_by_wdpa
+def get_by_wdpa(id, geojson, area_ha):
+    """Wdpa Endpoint"""
+    logging.info('[ROUTER]: Getting biomassloss by wdpa')
+    return analyze(geojson, area_ha)
+
+
+@whrc_biomass_endpoints_v1.route('/admin/<iso>', strict_slashes=False, methods=['GET'])
+@get_geo_by_national
+def get_by_national(iso, geojson, area_ha):
+    """National Endpoint"""
+    logging.info('[ROUTER]: Getting biomassloss by national')
+    return analyze(geojson, area_ha)
+
+
+@whrc_biomass_endpoints_v1.route('/admin/<iso>/<id1>', strict_slashes=False, methods=['GET'])
+@get_geo_by_subnational
+def get_by_subnational(iso, id1, geojson, area_ha):
+    """Subnational Endpoint"""
+    logging.info('[ROUTER]: Getting biomassloss by subnational')
+    return analyze(geojson, area_ha)
+
+@whrc_biomass_endpoints_v1.route('/admin/<iso>/<id1>/<id2>', strict_slashes=False, methods=['GET'])
+@get_geo_by_regional
+def get_geo_by_regional(iso, id1, id2, geojson, area_ha):
+    """Subnational Endpoint"""
+    logging.info('[ROUTER]: Getting biomassloss by subnational')
+    return analyze(geojson, area_ha)

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -18,6 +18,17 @@ def serialize_umd(analysis, type):
         }
     }
 
+
+def serialize_whrc_biomass(analysis, type):
+    """."""
+    return {
+        'id': None,
+        'type': type,
+        'attributes': {
+            'biomass': analysis.get('biomass', None)
+        }
+    }
+
 def serialize_histogram(analysis, type):
     """."""
 

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -64,6 +64,20 @@
 							"path": "/api/v1/whrc-biomass"
 						}
 						},{
+							"path": "/v1/whrc-biomass/use/:name/:id",
+							"method": "GET",
+							"redirect": {
+								"method": "GET",
+								"path": "/api/v1/whrc-biomass/use/:name/:id"
+							}
+							},{
+								"path": "/v1/whrc-biomass/wdpa/:id",
+								"method": "GET",
+								"redirect": {
+									"method": "GET",
+									"path": "/api/v1/whrc-biomass/wpda/:id"
+								}
+								},{
 		"path": "/v1/forma250gfw",
 		"method": "GET",
 		"redirect": {

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -29,6 +29,41 @@
 			"path": "/api/v1/umd-loss-gain/wdpa/:id"
 		}
     },{
+			"path": "/v1/whrc-biomass",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/whrc-biomass"
+			}
+			},{
+				"path": "/v1/whrc-biomass",
+				"method": "POST",
+				"redirect": {
+					"method": "POST",
+					"path": "/api/v1/whrc-biomass"
+				}
+				},{
+					"path": "/v1/whrc-biomass/use/:name/:id",
+					"method": "GET",
+					"redirect": {
+						"method": "GET",
+						"path": "/api/v1/whrc-biomass/use/:name/:id"
+					}
+					},{
+					"path": "/v1/whrc-biomass/wdpa/:id",
+					"method": "GET",
+					"redirect": {
+						"method": "GET",
+						"path": "/api/v1/whrc-biomass/wdpa/:id"
+					}
+					},{
+						"path": "/v1/whrc-biomass",
+						"method": "GET",
+						"redirect": {
+							"method": "GET",
+							"path": "/api/v1/whrc-biomass"
+						}
+						},{
 		"path": "/v1/forma250gfw",
 		"method": "GET",
 		"redirect": {


### PR DESCRIPTION
This PR adds a new micro-service at v1/whrc-biomass which should include 
`v1/whrc-biomass?geostore=<geostore>`
`v1/whrc-biomass/admin/<iso>/<admin1>/<admin2>`  (endpoints from admin0 - admin2).

The data source are from WHRC updated biomass layer on EE (and Hansen 2017 composite data). The biomass data correspond to the GFW 3.0 map layer Aboveground live woody biomass density (Climate tab). This micro-service should be hooked up to the analysis config of that layer.