### PR TITLE
Feature/update biomass loss

### DIFF
--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -44,7 +44,6 @@ app = Flask(__name__)
 # Routing
 app.register_blueprint(hansen_endpoints_v1, url_prefix='/api/v1/umd-loss-gain')
 app.register_blueprint(forma250_endpoints_v1, url_prefix='/api/v1/forma250gfw')
-app.register_blueprint(hansen_endpoints_v1, url_prefix='/api/v1/whrc-biomass')
 app.register_blueprint(biomass_loss_endpoints_v1, url_prefix='/api/v1/biomass-loss')
 app.register_blueprint(landsat_tiles_endpoints_v1, url_prefix='/api/v1/landsat-tiles')
 app.register_blueprint(sentinel_tiles_endpoints_v1, url_prefix='/api/v1/sentinel-tiles')

--- a/gfwanalysis/config/base.py
+++ b/gfwanalysis/config/base.py
@@ -28,10 +28,9 @@ SETTINGS = {
             'sea-landcover': 'projects/wri-datalab/gfw-api/sea-landcover',
             'forma250GFW': 'projects/wri-datalab/FORMA250',
             'whrc_biomass':'projects/wri-datalab/WHRC_CARBON',
-            'biomassloss': {
-                'hansen_loss_thresh': 'HANSEN/gfw_loss_by_year_threshold_2015',
-                'biomass_2000': 'users/davethau/whrc_carbon_test/carbon'
-            }
+            # 'biomassloss': {
+            #     'hansen_loss_thresh': 'HANSEN/gfw_loss_by_year_threshold_2015'
+            # }
         },
         'lulc_band': {
             'globcover': 'landcover',

--- a/gfwanalysis/routes/api/v1/biomass_loss_router.py
+++ b/gfwanalysis/routes/api/v1/biomass_loss_router.py
@@ -76,11 +76,12 @@ def get_by_national(iso, geojson, area_ha):
     return analyze(geojson, area_ha)
 
 
-@biomass_loss_endpoints_v1.route('/admin/<iso>/<admin>', strict_slashes=False, methods=['GET'])
+@biomass_loss_endpoints_v1.route('/admin/<iso>/<id1>', strict_slashes=False, methods=['GET'])
 @get_geo_by_subnational
-def get_by_subnational(iso, admin, geojson, area_ha):
+def get_by_subnational(iso, id1, geojson, area_ha):
     """Subnational Endpoint"""
     logging.info('[ROUTER]: Getting biomassloss by admin1')
+    logging.info(f'[ROUTER]: admin1 area_ha = {area_ha}')
     return analyze(geojson, area_ha)
 
 @biomass_loss_endpoints_v1.route('/admin/<iso>/<id1>/<id2>', strict_slashes=False, methods=['GET'])

--- a/gfwanalysis/routes/api/v1/biomass_loss_router.py
+++ b/gfwanalysis/routes/api/v1/biomass_loss_router.py
@@ -11,7 +11,7 @@ from gfwanalysis.routes.api import error, set_params
 from gfwanalysis.services.analysis.biomass_loss_service import BiomassLossService
 from gfwanalysis.validators import validate_geostore
 from gfwanalysis.middleware import get_geo_by_hash, get_geo_by_use, get_geo_by_wdpa, \
-    get_geo_by_national, get_geo_by_subnational
+    get_geo_by_national, get_geo_by_subnational, get_geo_by_regional
 from gfwanalysis.errors import BiomassLossError
 from gfwanalysis.serializers import serialize_biomass
 
@@ -72,13 +72,20 @@ def get_by_wdpa(id, geojson, area_ha):
 @get_geo_by_national
 def get_by_national(iso, geojson, area_ha):
     """National Endpoint"""
-    logging.info('[ROUTER]: Getting biomassloss by national')
+    logging.info('[ROUTER]: Getting biomassloss by iso')
     return analyze(geojson, area_ha)
 
 
-@biomass_loss_endpoints_v1.route('/admin/<iso>/<id1>', strict_slashes=False, methods=['GET'])
+@biomass_loss_endpoints_v1.route('/admin/<iso>/<admin>', strict_slashes=False, methods=['GET'])
 @get_geo_by_subnational
-def get_by_subnational(iso, id1, geojson, area_ha):
+def get_by_subnational(iso, admin, geojson, area_ha):
     """Subnational Endpoint"""
-    logging.info('[ROUTER]: Getting biomassloss by subnational')
+    logging.info('[ROUTER]: Getting biomassloss by admin1')
+    return analyze(geojson, area_ha)
+
+@biomass_loss_endpoints_v1.route('/admin/<iso>/<id1>/<id2>', strict_slashes=False, methods=['GET'])
+@get_geo_by_regional
+def get_geo_by_regional(iso, id1, id2, geojson, area_ha):
+    """Subnational Endpoint"""
+    logging.info('[ROUTER]: Getting biomassloss by admin2')
     return analyze(geojson, area_ha)

--- a/gfwanalysis/routes/api/v1/hansen_router.py
+++ b/gfwanalysis/routes/api/v1/hansen_router.py
@@ -53,7 +53,7 @@ def analyze(geojson, area_ha):
 @get_geo_by_hash
 def get_by_geostore(geojson, area_ha):
     """Analyze by geostore"""
-    logging.info('[ROUTER]: Getting umd by world')
+    logging.info('[ROUTER]: Getting Hansen by geostore')
     return analyze(geojson, area_ha)
 
 
@@ -61,7 +61,7 @@ def get_by_geostore(geojson, area_ha):
 @get_geo_by_use
 def get_by_use(name, id, geojson, area_ha):
     """Analyze by use"""
-    logging.info('[ROUTER]: Getting umd by use')
+    logging.info('[ROUTER]: Getting Hansen by use area')
     return analyze(geojson, area_ha)
 
 
@@ -69,5 +69,5 @@ def get_by_use(name, id, geojson, area_ha):
 @get_geo_by_wdpa
 def get_by_wdpa(id, geojson, area_ha):
     """Analyze by wdpa"""
-    logging.info('[ROUTER]: Getting umd by wdpa')
+    logging.info('[ROUTER]: Getting Hansen by wdpa area')
     return analyze(geojson, area_ha)

--- a/gfwanalysis/routes/api/v1/whrc_biomass_router.py
+++ b/gfwanalysis/routes/api/v1/whrc_biomass_router.py
@@ -21,8 +21,9 @@ def analyze(geojson, area_ha):
     """Analyze WHRC Biomass"""
     logging.info('[ROUTER]: Getting biomass')
     if not geojson:
-        return error(status=400, detail='Geojson is required')
+        return error(status=400, detail='A Geojson argument is required')
     threshold, start, end = set_params()
+    logging.info(f'[ROUTER - params]: biomass params {threshold}, {start}, {end}')
     try:
         data = WHRCBiomassService.analyze(
             geojson=geojson,
@@ -67,7 +68,7 @@ def get_by_wdpa(id, geojson, area_ha):
 @get_geo_by_national
 def get_by_national(iso, geojson, area_ha):
     """National Endpoint"""
-    logging.info('[ROUTER]: Getting biomass by national')
+    logging.info('[ROUTER]: Getting biomass loss by iso')
     return analyze(geojson, area_ha)
 
 
@@ -75,12 +76,12 @@ def get_by_national(iso, geojson, area_ha):
 @get_geo_by_subnational
 def get_by_subnational(iso, id1, geojson, area_ha):
     """Subnational Endpoint"""
-    logging.info('[ROUTER]: Getting biomass by subnational')
+    logging.info('[ROUTER]: Getting biomass loss by admin1')
     return analyze(geojson, area_ha)
 
 @whrc_biomass_endpoints_v1.route('/admin/<iso>/<id1>/<id2>', strict_slashes=False, methods=['GET'])
 @get_geo_by_regional
 def get_geo_by_regional(iso, id1, id2, geojson, area_ha):
     """Subnational Endpoint"""
-    logging.info('[ROUTER]: Getting biomass by subnational')
+    logging.info('[ROUTER]: Getting biomass loss by admin2 ')
     return analyze(geojson, area_ha)

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -82,12 +82,12 @@ def serialize_biomass(analysis, type):
         'id': None,
         'type': type,
         'attributes': {
-            'biomass': analysis.get('biomass', None),
-            'biomassLoss': analysis.get('biomass_loss', None),
-            'biomassLossByYear': analysis.get('biomass_loss_by_year', None),
-            'cLossByYear': analysis.get('c_loss_by_year', None),
-            'co2LossByYear': analysis.get('co2_loss_by_year', None),
-            'treeLossByYear': analysis.get('tree_loss_by_year', None),
+            #'biomass': analysis.get('biomass', None),  # this should be from whrc_biomass service
+            'biomassLoss': analysis.get('biomassLoss', None),
+            'biomassLossByYear': analysis.get('biomassLossByYear', None),
+            'cLossByYear': analysis.get('cLossByYear', None),
+            'co2LossByYear': analysis.get('co2LossByYear', None),
+            #'treeLossByYear': analysis.get('treeLossByYear', None), # this should be from hansen service
             'areaHa': analysis.get('area_ha', None)
         }
     }

--- a/gfwanalysis/services/analysis/biomass_loss_service.py
+++ b/gfwanalysis/services/analysis/biomass_loss_service.py
@@ -18,10 +18,10 @@ class BiomassLossService(object):
 
         # Reducer arguments
         reduce_args = {
-            'reducer': ee.Reducer.sum(),
+            'reducer': ee.Reducer.sum().unweighted(),
             'geometry': region,
             'bestEffort': True,
-            'scale': 90
+            'scale': 30
         }
 
         # Calculate stats
@@ -40,10 +40,10 @@ class BiomassLossService(object):
 
         # Reducer arguments
         reduce_args = {
-            'reducer': ee.Reducer.sum(),
+            'reducer': ee.Reducer.sum().unweighted(),
             'geometry': region,
             'bestEffort': True,
-            'scale': 90
+            'scale': 30
         }
 
         # Calculate stats 10000 ha, 10^6 to transform from Mg (10^6g) to Tg(10^12g) and 255 as is the pixel value when true.

--- a/gfwanalysis/services/analysis/biomass_loss_service.py
+++ b/gfwanalysis/services/analysis/biomass_loss_service.py
@@ -1,100 +1,85 @@
 """Biomass-Loss SERVICE"""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import logging
 
 import ee
 from gfwanalysis.errors import BiomassLossError
 from gfwanalysis.config import SETTINGS
 from gfwanalysis.utils.geo import get_thresh_image, get_region, dict_unit_transform, \
-    sum_range, dates_selector
+     sum_range, dates_selector, squaremeters_to_ha
 
 
 class BiomassLossService(object):
 
     @staticmethod
-    def _gee_hansen(geojson, thresh):
-        image = get_thresh_image(str(thresh), SETTINGS.get('gee').get('assets').get('biomassloss').get('hansen_loss_thresh'))
-        region = get_region(geojson)
-
-        # Reducer arguments
-        reduce_args = {
-            'reducer': ee.Reducer.sum().unweighted(),
-            'geometry': region,
-            'bestEffort': True,
-            'scale': 30
-        }
-
-        # Calculate stats
-        area_stats = image.divide(10000 * 255.0) \
-            .multiply(ee.Image.pixelArea()) \
-            .reduceRegion(**reduce_args)
-
-        return area_stats.getInfo()
-
-    @staticmethod
-    def _gee_biomass(geom, thresh):
-
-        image1 = get_thresh_image(str(thresh), SETTINGS.get('gee').get('assets').get('biomassloss').get('hansen_loss_thresh'))
-        image2 = ee.Image(SETTINGS.get('gee').get('assets').get('biomassloss').get('biomass_2000'))
-        region = get_region(geom)
-
-        # Reducer arguments
-        reduce_args = {
-            'reducer': ee.Reducer.sum().unweighted(),
-            'geometry': region,
-            'bestEffort': True,
-            'scale': 30
-        }
-
-        # Calculate stats 10000 ha, 10^6 to transform from Mg (10^6g) to Tg(10^12g) and 255 as is the pixel value when true.
-        area_stats = image2.multiply(image1) \
-            .divide(10000 * 255.0) \
-            .multiply(ee.Image.pixelArea()) \
-            .reduceRegion(**reduce_args)
-
-        carbon_stats = image2.multiply(ee.Image.pixelArea().divide(10000)).reduceRegion(**reduce_args)
-        area_results = area_stats.combine(carbon_stats).getInfo()
-
-        return area_results
-
-
-
-    @staticmethod
     def analyze(threshold, geojson, begin, end):
         """
+        Takes WHRC Carbon and Hansen loss data and returns amount of biomass, carbon and co2 lost
+        by time.
         """
         try:
+            logging.info(f'[biomass-loss-service]: with properties passed: {threshold}, {begin}, {end}')
             # hansen tree cover loss by year
-            logging.info('getting hansen')
-            hansen_loss_by_year = BiomassLossService._gee_hansen(geojson, threshold)
-            # Biomass loss by year
-            logging.info('getting biomass')
-            loss_by_year = BiomassLossService._gee_biomass(geojson, threshold)
-            # biomass (UMD doesn't permit disaggregation of forest gain by threshold).
-            biomass = loss_by_year['carbon']
-            loss_by_year.pop("carbon", None)
+            d = {}
+            # Extract int years to work with for time range
+            start_year = int(begin.split('-')[0]) - 2000
+            end_year = int(end.split('-')[0]) - 2000
 
-            # Carbon (UMD doesn't permit disaggregation of forest gain by threshold).
-            carbon_loss = dict_unit_transform(loss_by_year, 0.5)
+            # Gather assets
+            band_name = f'loss_{threshold}'
+            hansen_asset = SETTINGS.get('gee').get('assets').get('hansen')
+            biomass_asset = SETTINGS.get('gee').get('assets').get('whrc_biomass')
+            hansen = ee.Image(hansen_asset).select(band_name)
+            biomass = ee.ImageCollection(biomass_asset).max()
+            region = get_region(geojson)
+            logging.info(f'[biomass-loss-service]: built assets for analysis, using Hansen band {band_name}')
 
-            # CO2 (UMD doesn't permit disaggregation of forest gain by threshold).
-            carbon_dioxide_loss = dict_unit_transform(carbon_loss, 3.67)
+            # Reducer arguments
+            reduce_args = {
+                'reducer': ee.Reducer.sum().unweighted(),
+                'geometry': region,
+                'bestEffort': True,
+                'scale': 30,
+                'tileScale': 16
+            }
 
-            # Reduce loss by year for supplied begin and end year
-            begin = begin.split('-')[0]
-            end = end.split('-')[0]
-            biomass_loss = sum_range(loss_by_year, begin, end)
+            # mask hasen data with itself (important step to prevent over-counting)
+            hansen = hansen.mask(hansen)
 
-            # Prepare result object
-            result = {}
-            result['biomass'] = biomass
-            result['biomass_loss'] = biomass_loss
-            result['biomass_loss_by_year'] = dates_selector(loss_by_year, begin, end)
-            result['tree_loss_by_year'] = dates_selector(hansen_loss_by_year, begin, end)
-            result['c_loss_by_year'] = dates_selector(carbon_loss, begin, end)
-            result['co2_loss_by_year'] = dates_selector(carbon_dioxide_loss, begin, end)
+            # Calculate area of loss within a specific year range (inclusive) - not needed
+            #area_stats = hansen.gte(start_year).And(hansen.lte(end_year)).multiply(ee.Image.pixelArea()).reduceRegion(**reduce_args)
+            #d['areaHa'] = squaremeters_to_ha(area_stats.getInfo().get(band_name))
 
-            return result
+            # Calculate annual biomass loss with a collection operation method
+            def reduceFunction(img):
+                out = img.reduceRegion(**reduce_args)
+                return ee.Feature(None, img.toDictionary().combine(out))
+
+            ## Calculate annual biomass loss - add subset images to a collection and then map a reducer to it
+            collectionG = ee.ImageCollection([biomass.mask(hansen.updateMask(hansen.eq(year))).set({'year': 2000+year})
+                                               for year in range(start_year, end_year + 1)])
+            output = collectionG.map(reduceFunction).getInfo()
+
+            # # Convert to carbon and co2 values and add to output dictionary
+            biomass_to_carbon = 0.5
+            carbon_to_co2 = 3.67
+
+            d['biomassLossByYear'] = {}
+            d['cLossByYear'] = {}
+            d['co2LossByYear'] = {}
+            for row in output.get('features'):
+                yr = row.get('properties').get('year')
+                d['biomassLossByYear'][yr] = row.get('properties').get('b1')
+                d['cLossByYear'][yr] = float(f"{d.get('biomassLossByYear').get(yr) * biomass_to_carbon :3.2f}")
+                d['co2LossByYear'][yr] = float(f"{d.get('cLossByYear').get(yr) * carbon_to_co2 :3.2f}")
+
+            # # Calculate total biomass loss
+            d['biomassLoss'] = sum([d.get('biomassLossByYear').get(y) for y in d.get('biomassLossByYear')])
+            return d
 
         except Exception as error:
             logging.error(str(error))

--- a/gfwanalysis/services/analysis/hansen_service.py
+++ b/gfwanalysis/services/analysis/hansen_service.py
@@ -68,7 +68,7 @@ class HansenService(object):
             else:
                 # Identify loss area per year from beginning year to end year
                 d['loss'] = {}
-                tmp_img = gfw_data.select(loss_band)
+                tmp_img = gfw_data.select(loss_band).mask(gfw_data.select(loss_band))
                 for year in range(begin, end+1):
                     year_loss = tmp_img.updateMask(tmp_img.eq(year)).divide(year).multiply(
                                 ee.Image.pixelArea()).reduceRegion(**reduce_args).getInfo()

--- a/gfwanalysis/services/analysis/hansen_service.py
+++ b/gfwanalysis/services/analysis/hansen_service.py
@@ -36,11 +36,14 @@ class HansenService(object):
             extent_2010_asset = SETTINGS.get('gee').get('assets').get('hansen_2010_extent')
             begin = int(begin.split('-')[0][2:])
             end = int(end.split('-')[0][2:])
+            d['loss_start_year'] = begin
+            d['loss_end_year'] = end
             region = get_region(geojson)
             reduce_args = {'reducer': ee.Reducer.sum().unweighted(),
                            'geometry': region,
                            'bestEffort': True,
-                           'scale': 30}
+                           'scale': 30,
+                           'tileScale': 16}
             gfw_data = ee.Image(asset_id)
             loss_band = 'loss_{0}'.format(threshold)
             cover_band = 'tree_{0}'.format(threshold)
@@ -57,23 +60,26 @@ class HansenService(object):
             gain = gfw_data.select('gain').divide(255.0).multiply(
                             ee.Image.pixelArea()).reduceRegion(**reduce_args).getInfo()
             d['gain'] = squaremeters_to_ha(gain['gain'])
+            # Mask loss with itself to avoid overcounting errors
+            tmp_img = gfw_data.select(loss_band).mask(gfw_data.select(loss_band))
             if aggregate_values:
                 # Identify one loss area from begin year up untill end year
-                tmp_img = gfw_data.select(loss_band)
                 loss_area_img = tmp_img.gte(begin).And(tmp_img.lte(end)).multiply(ee.Image.pixelArea())
                 loss_total = loss_area_img.reduceRegion(**reduce_args).getInfo()
                 d['loss'] = squaremeters_to_ha(loss_total[loss_band])
-                d['loss_start_year'] = begin
-                d['loss_end_year'] = end
             else:
-                # Identify loss area per year from beginning year to end year
+                # Identify loss area per year from beginning year to end year (inclusive)
+                def reduceFunction(img):
+                    out = img.reduceRegion(**reduce_args)
+                    return ee.Feature(None, out)
+
+                ## Calculate annual biomass loss - add subset images to a collection and then map a reducer to it
+                collectionG = ee.ImageCollection([tmp_img.updateMask(tmp_img.eq(year)).divide(year).multiply(
+                                ee.Image.pixelArea()).set({'year': 2000+year}) for year in range(begin, end + 1)])
+                output = collectionG.map(reduceFunction).getInfo()
                 d['loss'] = {}
-                tmp_img = gfw_data.select(loss_band).mask(gfw_data.select(loss_band))
-                for year in range(begin, end+1):
-                    year_loss = tmp_img.updateMask(tmp_img.eq(year)).divide(year).multiply(
-                                ee.Image.pixelArea()).reduceRegion(**reduce_args).getInfo()
-                    tmp_loss_value = year_loss['loss_{}'.format(str(threshold))]
-                    d['loss']['{}'.format(year + 2000)] = squaremeters_to_ha(tmp_loss_value)
+                for row, yr in zip(output.get('features'), range(begin, end+1)):
+                    d['loss'][yr+2000] = squaremeters_to_ha(row.get('properties').get(loss_band))
             return d
         except Exception as error:
             logging.error(str(error))

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -234,11 +234,19 @@
 			}
 		},
 		{
-			"path": "/v1/biomass-loss/admin/:iso/:id1",
+			"path": "/v1/biomass-loss/admin/:iso/:admin",
 			"method": "GET",
 			"redirect": {
 				"method": "GET",
-				"path": "/api/v1/biomass-loss/admin/:iso/:id1"
+				"path": "/api/v1/biomass-loss/admin/:iso/:admin"
+			}
+		},
+		{
+			"path": "/v1/biomass-loss/admin/:iso/:admin/:admin2",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/biomass-loss/admin/:iso/:admin/:admin2"
 			}
 		},
 		{


### PR DESCRIPTION
Big changes afoot! These service updates include:

* WHRC-biomass service fully functional (including geostore, use, wdpa, admin 0 - 2)
`api/v1/whrc-biomass?geostore=<id>&thresh=10`
* Speed-up of Hansen loss by year (geostore, use, wdpa)
`/v1/umd-loss-gain?geostore=<id>&thresh=10&aggregate_values=false`
* Biomass loss by year (including geostore, use, wdpa, admin 0 -2)
`/v1/biomass-loss?geostore=<id>&thresh=10`

*Nb. biomass loss by year returns less info than it used to, due to 1) the breakout of biomass into its own service (WHRC biomass), and 2) removing tree cover loss from the service (again that should only be handled by the Hansen service). This means these changes will probably break the old GFW climate analysis widget when deployed to production.*
