### PR TITLE
change to update services that use geostore/admin to v2 endpoint

### DIFF
--- a/gfwanalysis/services/geostore_service.py
+++ b/gfwanalysis/services/geostore_service.py
@@ -48,24 +48,27 @@ class GeostoreService(object):
     @staticmethod
     def get_national(iso):
         config = {
-            'uri': '/geostore/admin/'+iso,
-            'method': 'GET'
+            'uri': '/v2/geostore/admin/'+iso,
+            'method': 'GET',
+            'ignore_version': True
         }
         return GeostoreService.execute(config)
 
     @staticmethod
     def get_subnational(iso, id1):
         config = {
-            'uri': '/geostore/admin/'+iso+'/'+id1,
-            'method': 'GET'
+            'uri': '/v2/geostore/admin/'+iso+'/'+id1,
+            'method': 'GET',
+            'ignore_version': True
         }
         return GeostoreService.execute(config)
 
     @staticmethod
     def get_regional(iso, id1, id2):
         config = {
-            'uri': '/geostore/admin/'+iso+'/'+id1+'/'+id2,
-            'method': 'GET'
+            'uri': '/v2/geostore/admin/'+iso+'/'+id1+'/'+id2,
+            'method': 'GET',
+            'ignore_version': True
         }
         return GeostoreService.execute(config)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==0.12.4
 earthengine-api==0.1.102
-CTRegisterMicroserviceFlask==0.3.7
+CTRegisterMicroserviceFlask==0.4.0
 requests==2.20.0
 shapely==1.5.13
 pyproj==1.9.5.1


### PR DESCRIPTION
Updated CTRegister package dependency so that we are able to force geostore to use /v2 endpoint when attempting to retrieve data from geostore/admin (to use GADM3.6).