### PR TITLE
first version of soil analysis endpoint

### DIFF
--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -17,7 +17,7 @@ from gfwanalysis.routes.api import error
 from gfwanalysis.routes.api.v1 import hansen_endpoints_v1, forma250_endpoints_v1, \
     biomass_loss_endpoints_v1, landsat_tiles_endpoints_v1, histogram_endpoints_v1, \
     landcover_endpoints_v1, sentinel_tiles_endpoints_v1, highres_tiles_endpoints_v1, \
-    recent_tiles_endpoints_v1, whrc_biomass_endpoints_v1
+    recent_tiles_endpoints_v1, whrc_biomass_endpoints_v1, soil_carbon_endpoints_v1
 from gfwanalysis.routes.api.v2 import biomass_loss_endpoints_v2
 from gfwanalysis.utils.files import load_config_json
 import CTRegisterMicroserviceFlask
@@ -54,6 +54,8 @@ app.register_blueprint(recent_tiles_endpoints_v1, url_prefix='/api/v1/recent-til
 app.register_blueprint(histogram_endpoints_v1, url_prefix='/api/v1/loss-by-landcover')
 app.register_blueprint(landcover_endpoints_v1, url_prefix='/api/v1/landcover')
 app.register_blueprint(whrc_biomass_endpoints_v1, url_prefix='/api/v1/whrc-biomass')
+app.register_blueprint(soil_carbon_endpoints_v1, url_prefix='/api/v1/soil-carbon')
+
 
 # CT
 info = load_config_json('register')

--- a/gfwanalysis/config/base.py
+++ b/gfwanalysis/config/base.py
@@ -23,6 +23,7 @@ SETTINGS = {
             'liberia': 'projects/wri-datalab/gfw-api/lbr-landcover',
             'ifl2000': 'projects/wri-datalab/gfw-api/ifl-world',
             'mangroves': 'LANDSAT/MANGROVE_FORESTS/2000',
+            'soils_30m':'projects/wri-datalab/Soil_Organic_Carbon_30m',
             'primary-forest': 'projects/wri-datalab/gfw-api/primary-forest',
             'gfw-landcover-2015': 'projects/wri-datalab/gfw-api/globcover-2015-reclassified',
             'idn-landcover': 'projects/wri-datalab/gfw-api/idn-landcover',

--- a/gfwanalysis/errors.py
+++ b/gfwanalysis/errors.py
@@ -43,6 +43,8 @@ class WHRCBiomassError(Error):
 class BiomassLossError(Error):
     pass
 
+class soilCarbonError(Error):
+    pass
 
 class GeostoreNotFound(Error):
     pass

--- a/gfwanalysis/routes/api/v1/__init__.py
+++ b/gfwanalysis/routes/api/v1/__init__.py
@@ -8,3 +8,4 @@ from gfwanalysis.routes.api.v1.recent_router import recent_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.histogram_router import histogram_endpoints_v1
 from gfwanalysis.routes.api.v1.landcover_router import landcover_endpoints_v1
 from gfwanalysis.routes.api.v1.whrc_biomass_router import whrc_biomass_endpoints_v1
+from gfwanalysis.routes.api.v1.soil_carbon_router import soil_carbon_endpoints_v1

--- a/gfwanalysis/routes/api/v1/soil_carbon_router.py
+++ b/gfwanalysis/routes/api/v1/soil_carbon_router.py
@@ -1,0 +1,88 @@
+"""API ROUTER"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+
+from flask import jsonify, request, Blueprint
+from gfwanalysis.routes.api import error, set_params
+from gfwanalysis.services.analysis.soil_carbon_service_v1 import SoilCarbonService
+from gfwanalysis.validators import validate_geostore
+from gfwanalysis.middleware import get_geo_by_hash, get_geo_by_use, get_geo_by_wdpa, \
+    get_geo_by_national, get_geo_by_subnational, get_geo_by_regional
+from gfwanalysis.errors import soilCarbonError
+from gfwanalysis.serializers import serialize_soil_carbon
+
+soil_carbon_endpoints_v1 = Blueprint('soil_carbon', __name__)
+
+def analyze(geojson, area_ha):
+    """Analyze Soil Carbon"""
+    #logging.info('[ROUTER]: In Soil carbon router')
+    if not geojson:
+        return error(status=400, detail='A Geojson argument is required')
+    threshold, start, end, table = set_params()
+    #logging.info(f'[ROUTER]: soil carbon params {threshold}, {start}, {end}')
+    try:
+        data = SoilCarbonService.analyze(
+            geojson=geojson,
+            threshold=threshold)
+
+    except soilCarbonError as e:
+        logging.error('[ROUTER]: '+e.message)
+        return error(status=500, detail=e.message)
+    except Exception as e:
+        logging.error('[ROUTER]: '+str(e))
+        return error(status=500, detail='Generic Error')
+    data['area_ha'] = area_ha
+    data['soil_carbon_density'] = data['total_soil_carbon'].get('b1_first') / area_ha
+    return jsonify(data=serialize_soil_carbon(data, 'soil_carbon')), 200
+
+
+@soil_carbon_endpoints_v1.route('/', strict_slashes=False, methods=['GET', 'POST'])
+@validate_geostore
+@get_geo_by_hash
+def get_by_geostore(geojson, area_ha):
+    """By Geostore Endpoint"""
+    logging.info('[ROUTER]: Getting soil carbon by geostore')
+    return analyze(geojson, area_ha)
+
+
+@soil_carbon_endpoints_v1.route('/use/<name>/<id>', strict_slashes=False, methods=['GET'])
+@get_geo_by_use
+def get_by_use(name, id, geojson, area_ha):
+    """Use Endpoint"""
+    logging.info('[ROUTER]: Getting  soil carbon by use')
+    return analyze(geojson, area_ha)
+
+
+@soil_carbon_endpoints_v1.route('/wdpa/<id>', strict_slashes=False, methods=['GET'])
+@get_geo_by_wdpa
+def get_by_wdpa(id, geojson, area_ha):
+    """Wdpa Endpoint"""
+    logging.info('[ROUTER]: Getting  soil carbon by wdpa')
+    return analyze(geojson, area_ha)
+
+
+@soil_carbon_endpoints_v1.route('/admin/<iso>', strict_slashes=False, methods=['GET'])
+@get_geo_by_national
+def get_by_national(iso, geojson, area_ha):
+    """National Endpoint"""
+    logging.info('[ROUTER]: Getting  soil carbon loss by iso')
+    return analyze(geojson, area_ha)
+
+
+@soil_carbon_endpoints_v1.route('/admin/<iso>/<id1>', strict_slashes=False, methods=['GET'])
+@get_geo_by_subnational
+def get_by_subnational(iso, id1, geojson, area_ha):
+    """Subnational Endpoint"""
+    logging.info('[ROUTER]: Getting  soil carbon loss by admin1')
+    return analyze(geojson, area_ha)
+
+@soil_carbon_endpoints_v1.route('/admin/<iso>/<id1>/<id2>', strict_slashes=False, methods=['GET'])
+@get_geo_by_regional
+def get_by_regional(iso, id1, id2, geojson, area_ha):
+    """Subnational Endpoint"""
+    logging.info('[ROUTER]: Getting  soil carbon loss by admin2 ')
+    return analyze(geojson, area_ha)

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -49,6 +49,19 @@ def serialize_whrc_biomass(analysis, type):
         }
     }
 
+def serialize_soil_carbon(analysis, type):
+    """Return serialised soil carbon data"""
+    return {
+            'id': None,
+            'type': type,
+            'attributes':{
+                'total_soil_carbon': analysis.get('total_soil_carbon', None).get('b1_first', None),
+                'soil_carbon_density': analysis.get('soil_carbon_density', None),
+                'areaHa': analysis.get('area_ha', None)
+            }
+    }
+
+
 def serialize_histogram(analysis, type):
     """."""
 

--- a/gfwanalysis/services/analysis/soil_carbon_service_v1.py
+++ b/gfwanalysis/services/analysis/soil_carbon_service_v1.py
@@ -1,0 +1,34 @@
+"""Soil Carbon SERVICE"""
+
+import logging
+import ee
+from gfwanalysis.errors import soilCarbonError
+from gfwanalysis.config import SETTINGS
+from gfwanalysis.utils.geo import get_region, squaremeters_to_ha
+
+
+class SoilCarbonService(object):
+
+    @staticmethod
+    def analyze(threshold, geojson):
+        """For a given Hansen threshold mask on WHRC biomass data
+        and geometry return a dictionary of total t/ha.
+        """
+        #logging.info('[Soil Carbon Service]: In Soil carbon service')
+        try:
+            d = {}
+            soil_carbon_asset = SETTINGS.get('gee').get('assets').get('soils_30m')
+            region = get_region(geojson)
+            reduce_args = {'reducer': ee.Reducer.sum().unweighted(),
+                           'geometry': region,
+                           'bestEffort': True,
+                           'scale': 30}
+            sc = ee.Image(soil_carbon_asset).multiply(ee.Image.pixelArea().divide(10000))
+            # Identify soil carbon value
+            sc_value = sc.reduceRegion(**reduce_args).getInfo()
+            d['total_soil_carbon'] = sc_value
+            #logging.info(f'[Soil Carbon Service]:d = {d}')
+            return d
+        except Exception as error:
+            logging.error(str(error))
+            raise soilCarbonError(message='Error in soil carbon analysis')

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -35,14 +35,6 @@
 		},
 		{
 			"path": "/v1/whrc-biomass",
-			"method": "GET",
-			"redirect": {
-				"method": "GET",
-				"path": "/api/v1/whrc-biomass"
-			}
-		},
-		{
-			"path": "/v1/whrc-biomass",
 			"method": "POST",
 			"redirect": {
 				"method": "POST",
@@ -95,6 +87,54 @@
 			"redirect": {
 				"method": "GET",
 				"path": "/api/v1/whrc-biomass/admin/:iso/:admin/:admin2"
+			}
+		},
+		{
+			"path": "/v1/soil-carbon",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/soil-carbon"
+			}
+		},
+		{
+			"path": "/v1/soil-carbon/use/:name/:id",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/soil-carbon/use/:name/:id"
+			}
+		},
+		{
+			"path": "/v1/soil-carbon/wdpa/:id",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/soil-carbon/wdpa/:id"
+			}
+		},
+		{
+			"path": "/v1/soil-carbon/admin/:iso",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/soil-carbon/admin/:iso"
+			}
+		},
+		{
+			"path": "/v1/soil-carbon/admin/:iso/:admin",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/soil-carbon/admin/:iso/:admin"
+			}
+		},
+		{
+			"path": "/v1/soil-carbon/admin/:iso/:admin/:admin2",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/soil-carbon/admin/:iso/:admin/:admin2"
 			}
 		},
 		{


### PR DESCRIPTION
Added endpoint for `api/v1/soil-carbon` to accompany the new soil carbon layer in the climate section of GFW.

Endpoints include routes for geostore, admin (0-2), and use.

E.g.

`/api/v1/soil-carbon/wdpa/352258`
```json
{
    "data": {
        "attributes": {
            "areaHa": 8057663.673799788,
            "soil_carbon_density": 97.02513890255196,
            "total_soil_carbon": 781795937.1804715
        },
        "id": null,
        "type": "soil_carbon"
    }
}
```