### PR TITLE
remove precison on density

### DIFF
--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -44,7 +44,7 @@ def serialize_whrc_biomass(analysis, type):
         'type': type,
         'attributes': {
             'totalBiomass': analysis.get('biomass', None).get('b1', None),
-            'biomassDensity': analysis.get('biomass_density'),
+            'biomassDensity': int(analysis.get('biomass_density')),
             'areaHa': analysis.get('area_ha', None)
         }
     }
@@ -56,7 +56,7 @@ def serialize_soil_carbon(analysis, type):
             'type': type,
             'attributes':{
                 'total_soil_carbon': analysis.get('total_soil_carbon', None).get('b1_first', None),
-                'soil_carbon_density': analysis.get('soil_carbon_density', None),
+                'soil_carbon_density': int(analysis.get('soil_carbon_density', None)),
                 'areaHa': analysis.get('area_ha', None)
             }
     }


### PR DESCRIPTION
This PR should remove the precision on the density values for the layers shown in the image below. (I.e. the circled data should only return as INT type values, after this PR is applied.)
![screenshot 2019-02-22 at 09 55 18](https://user-images.githubusercontent.com/6503031/53230992-44d87780-3688-11e9-9d1c-5cc4b08aa3d8.png)
