### PR TITLE
Feature/soil carbon service

### DIFF
--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -17,7 +17,7 @@ from gfwanalysis.routes.api import error
 from gfwanalysis.routes.api.v1 import hansen_endpoints_v1, forma250_endpoints_v1, \
     biomass_loss_endpoints_v1, landsat_tiles_endpoints_v1, histogram_endpoints_v1, \
     landcover_endpoints_v1, sentinel_tiles_endpoints_v1, highres_tiles_endpoints_v1, \
-    recent_tiles_endpoints_v1, whrc_biomass_endpoints_v1, soil_carbon_endpoints_v1, \
+    recent_tiles_endpoints_v1, whrc_biomass_endpoints_v1, mangrove_biomass_endpoints_v1, soil_carbon_endpoints_v1, \
     recent_tiles_classifier_v1
 from gfwanalysis.routes.api.v2 import biomass_loss_endpoints_v2, landsat_tiles_endpoints_v2
 from gfwanalysis.utils.files import load_config_json

--- a/gfwanalysis/__init__.py
+++ b/gfwanalysis/__init__.py
@@ -55,6 +55,7 @@ app.register_blueprint(highres_tiles_endpoints_v1, url_prefix='/api/v1/highres-t
 app.register_blueprint(recent_tiles_endpoints_v1, url_prefix='/api/v1/recent-tiles')
 app.register_blueprint(histogram_endpoints_v1, url_prefix='/api/v1/loss-by-landcover')
 app.register_blueprint(landcover_endpoints_v1, url_prefix='/api/v1/landcover')
+app.register_blueprint(mangrove_biomass_endpoints_v1, url_prefix='/api/v1/mangrove-biomass')
 app.register_blueprint(whrc_biomass_endpoints_v1, url_prefix='/api/v1/whrc-biomass')
 app.register_blueprint(soil_carbon_endpoints_v1, url_prefix='/api/v1/soil-carbon')
 app.register_blueprint(recent_tiles_classifier_v1, url_prefix='/api/v1/recent-tiles-classifier')

--- a/gfwanalysis/config/base.py
+++ b/gfwanalysis/config/base.py
@@ -23,7 +23,7 @@ SETTINGS = {
             'liberia': 'projects/wri-datalab/gfw-api/lbr-landcover',
             'ifl2000': 'projects/wri-datalab/gfw-api/ifl-world',
             'mangroves': 'LANDSAT/MANGROVE_FORESTS/2000',
-            'mangrove_aboveground_biomass_density_2005': 'projects/wri-datalab/mangrove_aboveground_biomass_density_2005_image',
+            'mangrove_biomass': 'projects/wri-datalab/mangrove_aboveground_biomass_density_2005',
             'soils_30m':'projects/wri-datalab/Soil_Organic_Carbon_30m',
             'primary-forest': 'projects/wri-datalab/gfw-api/primary-forest',
             'gfw-landcover-2015': 'projects/wri-datalab/gfw-api/globcover-2015-reclassified',

--- a/gfwanalysis/config/base.py
+++ b/gfwanalysis/config/base.py
@@ -14,7 +14,7 @@ SETTINGS = {
     'gee': {
         'service_account': '390573081381-lm51tabsc8q8b33ik497hc66qcmbj11d@developer.gserviceaccount.com',
         'privatekey_file': BASE_DIR + '/privatekey.pem',
-        'assets': {
+        'assets': { 
             'hansen': 'projects/wri-datalab/HansenComposite_17',
             'hansen_2010_extent': 'projects/wri-datalab/HansenTreeCover2010',
             'hansen_2017_v1_5':'UMD/hansen/global_forest_change_2017_v1_5',
@@ -23,6 +23,7 @@ SETTINGS = {
             'liberia': 'projects/wri-datalab/gfw-api/lbr-landcover',
             'ifl2000': 'projects/wri-datalab/gfw-api/ifl-world',
             'mangroves': 'LANDSAT/MANGROVE_FORESTS/2000',
+            'mangrove_aboveground_biomass_density_2005': 'projects/wri-datalab/mangrove_aboveground_biomass_density_2005_image',
             'soils_30m':'projects/wri-datalab/Soil_Organic_Carbon_30m',
             'primary-forest': 'projects/wri-datalab/gfw-api/primary-forest',
             'gfw-landcover-2015': 'projects/wri-datalab/gfw-api/globcover-2015-reclassified',

--- a/gfwanalysis/errors.py
+++ b/gfwanalysis/errors.py
@@ -40,7 +40,10 @@ class FormaError(Error):
 class WHRCBiomassError(Error):
     pass
 
-class BiomassLossError(Error):
+class BiomassLossError(Error):    
+    pass
+
+class MangroveBiomassError(Error):
     pass
 
 class soilCarbonError(Error):

--- a/gfwanalysis/routes/api/v1/__init__.py
+++ b/gfwanalysis/routes/api/v1/__init__.py
@@ -7,6 +7,7 @@ from gfwanalysis.routes.api.v1.highres_router import highres_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.recent_router import recent_tiles_endpoints_v1
 from gfwanalysis.routes.api.v1.histogram_router import histogram_endpoints_v1
 from gfwanalysis.routes.api.v1.landcover_router import landcover_endpoints_v1
+from gfwanalysis.routes.api.v1.mangrove_biomass_router import mangrove_biomass_endpoints_v1
 from gfwanalysis.routes.api.v1.whrc_biomass_router import whrc_biomass_endpoints_v1
 from gfwanalysis.routes.api.v1.soil_carbon_router import soil_carbon_endpoints_v1
 from gfwanalysis.routes.api.v1.classification_service_router import recent_tiles_classifier_v1

--- a/gfwanalysis/routes/api/v1/mangrove_biomass_router.py
+++ b/gfwanalysis/routes/api/v1/mangrove_biomass_router.py
@@ -1,0 +1,81 @@
+"""API ROUTER"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+
+from flask import jsonify, request, Blueprint
+from gfwanalysis.routes.api import error, set_params
+from gfwanalysis.services.analysis.mangrove_biomass_service import MangroveBiomassService
+from gfwanalysis.validators import validate_geostore
+from gfwanalysis.middleware import get_geo_by_hash, get_geo_by_use, get_geo_by_wdpa, \
+    get_geo_by_national, get_geo_by_subnational, get_geo_by_regional
+from gfwanalysis.errors import MangroveBiomassError
+from gfwanalysis.serializers import serialize_mangrove_biomass
+
+mangrove_biomass_endpoints_v1 = Blueprint('_biomass', __name__)
+
+def analyze(geojson, area_ha):
+    """Analyze Mangrove Biomass"""
+    logging.info('[ROUTER]: Mangrove Getting biomass')
+    try:
+        data = MangroveBiomassService.analyze(geojson=geojson)
+    except MangroveBiomassError as e:
+        logging.error(f'[ROUTER]: {e.message}')
+        return error(status=500, detail=e.message)
+    except Exception as e:
+        logging.error(f'[ROUTER]: {str(e)}')
+        return error(status=500, detail='Generic Error')
+    data['area_ha'] = area_ha
+    data['biomass_density'] = data['biomass'].get('b1') / area_ha
+    return jsonify(data=serialize_mangrove_biomass(data, 'mangrove-biomass')), 200
+
+
+@mangrove_biomass_endpoints_v1.route('/', strict_slashes=False, methods=['GET', 'POST'])
+@validate_geostore
+@get_geo_by_hash
+def get_by_geostore(geojson, area_ha):
+    """By Geostore Endpoint"""
+    logging.info('[ROUTER]: Getting biomass by geostore')
+    return analyze(geojson, area_ha)
+
+
+@mangrove_biomass_endpoints_v1.route('/use/<name>/<id>', strict_slashes=False, methods=['GET'])
+@get_geo_by_use
+def get_by_use(name, id, geojson, area_ha):
+    """Use Endpoint"""
+    logging.info('[ROUTER]: Getting biomass by use')
+    return analyze(geojson, area_ha)
+
+
+@mangrove_biomass_endpoints_v1.route('/wdpa/<id>', strict_slashes=False, methods=['GET'])
+@get_geo_by_wdpa
+def get_by_wdpa(id, geojson, area_ha):
+    """Wdpa Endpoint"""
+    logging.info('[ROUTER]: Getting biomass by wdpa')
+    return analyze(geojson, area_ha)
+
+
+@mangrove_biomass_endpoints_v1.route('/admin/<iso>', strict_slashes=False, methods=['GET'])
+@get_geo_by_national
+def get_by_national(iso, geojson, area_ha):
+    """National Endpoint"""
+    logging.info('[ROUTER]: Getting biomass loss by iso')
+    return analyze(geojson, area_ha)
+
+
+@mangrove_biomass_endpoints_v1.route('/admin/<iso>/<id1>', strict_slashes=False, methods=['GET'])
+@get_geo_by_subnational
+def get_by_subnational(iso, id1, geojson, area_ha):
+    """Subnational Endpoint"""
+    logging.info('[ROUTER]: Getting biomass loss by admin1')
+    return analyze(geojson, area_ha)
+
+@mangrove_biomass_endpoints_v1.route('/admin/<iso>/<id1>/<id2>', strict_slashes=False, methods=['GET'])
+@get_geo_by_regional
+def get_by_regional(iso, id1, id2, geojson, area_ha):
+    """Subnational Endpoint"""
+    logging.info('[ROUTER]: Getting biomass loss by admin2 ')
+    return analyze(geojson, area_ha)

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -28,7 +28,6 @@ def serialize_classifier_output(analysis, type):
         }
     }
 
-
 def serialize_table_umd(analysis, type):
     """ Convert the aggregate_values=false Hansen response into a table"""
     rows = []
@@ -46,6 +45,17 @@ def serialize_table_umd(analysis, type):
         'attributes': rows
     }
 
+def serialize_mangrove_biomass(analysis, type):
+    """."""
+    return {
+        'id': None,
+        'type': type,
+        'attributes': {
+            'totalBiomass': analysis.get('biomass', None).get('b1', None),
+            'biomassDensity': int(analysis.get('biomass_density')),
+            'areaHa': analysis.get('area_ha', None)
+        }
+    }
 
 def serialize_whrc_biomass(analysis, type):
     """."""

--- a/gfwanalysis/services/analysis/mangrove_biomass_service.py
+++ b/gfwanalysis/services/analysis/mangrove_biomass_service.py
@@ -1,0 +1,33 @@
+"""MANGROVE BIOMASS SERVICE"""
+
+import logging
+
+import ee
+from gfwanalysis.errors import MangroveBiomassError
+from gfwanalysis.config import SETTINGS
+from gfwanalysis.utils.geo import get_region, squaremeters_to_ha, admin_0_simplify
+
+
+class MangroveBiomassService(object):
+
+    @staticmethod
+    def analyze(geojson):
+        """For a given geometry and mangrove biomass data
+        return a dictionary of total t/ha.
+        """
+        try:
+            d = {}
+            biomass_asset= SETTINGS.get('gee').get('assets').get('mangrove_biomass')
+            region = get_region(geojson)
+            reduce_args = {'reducer': ee.Reducer.sum().unweighted(),
+                           'geometry': region,
+                           'bestEffort': True,
+                           'scale': 30}
+            biomass = ee.Image(biomass_asset).multiply(ee.Image.pixelArea().divide(10000))
+            # Identify thresholded biomass value
+            biomass_value = biomass.reduceRegion(**reduce_args).getInfo()
+            d['biomass'] = biomass_value
+            return d
+        except Exception as error:
+            logging.error(str(error))
+            raise MangroveBiomassError(message='Error in Mangrove Biomass Analysis')

--- a/gfwanalysis/services/analysis/soil_carbon_service_v1.py
+++ b/gfwanalysis/services/analysis/soil_carbon_service_v1.py
@@ -17,13 +17,15 @@ class SoilCarbonService(object):
         #logging.info('[Soil Carbon Service]: In Soil carbon service')
         try:
             d = {}
+            hansen_asset = SETTINGS.get('gee').get('assets').get('hansen')
             soil_carbon_asset = SETTINGS.get('gee').get('assets').get('soils_30m')
             region = get_region(geojson)
             reduce_args = {'reducer': ee.Reducer.sum().unweighted(),
                            'geometry': region,
                            'bestEffort': True,
                            'scale': 30}
-            sc = ee.Image(soil_carbon_asset).multiply(ee.Image.pixelArea().divide(10000))
+            tc_mask = ee.Image(hansen_asset).select('tree_'+ str(threshold)).gt(0)
+            sc = ee.Image(soil_carbon_asset).multiply(ee.Image.pixelArea().divide(10000)).mask(tc_mask)
             # Identify soil carbon value
             sc_value = sc.reduceRegion(**reduce_args).getInfo()
             d['total_soil_carbon'] = sc_value

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -106,6 +106,54 @@
 			}
 		},
 		{
+			"path": "/v1/mangrove-biomass/use/:name/:id",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/mangrove-biomass/use/:name/:id"
+			}
+		},
+		{
+			"path": "/v1/mangrove-biomass/wdpa/:id",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/mangrove-biomass/wdpa/:id"
+			}
+		},
+		{
+			"path": "/v1/mangrove-biomass",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/mangrove-biomass"
+			}
+		},
+		{
+			"path": "/v1/mangrove-biomass/admin/:iso",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/mangrove-biomass/admin/:iso"
+			}
+		},
+		{
+			"path": "/v1/mangrove-biomass/admin/:iso/:admin",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/mangrove-biomass/admin/:iso/:admin"
+			}
+		},
+		{
+			"path": "/v1/mangrove-biomass/admin/:iso/:admin/:admin2",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/mangrove-biomass/admin/:iso/:admin/:admin2"
+			}
+		},
+		{
 			"path": "/v1/soil-carbon",
 			"method": "GET",
 			"redirect": {

--- a/microservice/register.json
+++ b/microservice/register.json
@@ -98,6 +98,14 @@
 			}
 		},
 		{
+			"path": "/v1/mangrove-biomass",
+			"method": "GET",
+			"redirect": {
+				"method": "GET",
+				"path": "/api/v1/mangrove-biomass"
+			}
+		},
+		{
 			"path": "/v1/soil-carbon",
 			"method": "GET",
 			"redirect": {


### PR DESCRIPTION
Masked soil_carbon image by hansen_tree_cover threshold before analysis.

Potential fix for:

> It appears that the soil carbon value is for the entire area of interest, not just for the forested pixels above the selected TCD threshold because the soil C value doesn't change when the TCD threshold changes. Can you mask the soil C values for the widget to the same ones being used for aboveground and belowground C to make the C pool comparison more direct? Currently, the soil C part of the pie chart includes all land, not just forested area, which isn't a meaningful comparison.
https://basecamp.com/1756858/projects/9386799/todos/356431425#comment_692040864