### PR TITLE
Removed option bestEffort: true and made maxPixels: 1e12

### DIFF
--- a/gfwanalysis/services/analysis/hansen_service.py
+++ b/gfwanalysis/services/analysis/hansen_service.py
@@ -42,9 +42,10 @@ class HansenService(object):
             region = get_region(geojson)
             reduce_args = {'reducer': ee.Reducer.sum().unweighted(),
                            'geometry': region,
-                           'bestEffort': True,
+                           'bestEffort': False,
                            'scale': 30,
-                           'tileScale': 16}
+                           'tileScale': 16,
+                           'maxPixels': 1e12}
             gfw_data = ee.Image(asset_id)
             hansen_v1_5 = ee.Image(hansen_v1_5_asset)
             loss_band = 'loss_{0}'.format(threshold)


### PR DESCRIPTION
Re: https://basecamp.com/3063126/projects/10728552/todos/386228349

Adjusted the arguments for the `ee.Reducer` so as to ensure the scale of calculations is always known. This means results should be more accurate, but means geostore objects  > 6500000 Ha will probably fail (by timeout), and analysis times for larger objects may increase.

- bestEffort is now `false`
- maxPixels is now `1e12`