### PR TITLE
Bugfix: Lat/Lon were inverted in the recent imagery services

### DIFF
--- a/gfwanalysis/services/analysis/highres_tiles.py
+++ b/gfwanalysis/services/analysis/highres_tiles.py
@@ -51,8 +51,8 @@ class HighResTiles(object):
         """
         logging.info("[HIGH RES] function initiated")
 
-        try:            
-            point = ee.Geometry.Point(float(lat), float(lon))
+        try:
+            point = ee.Geometry.Point(float(lon), float(lat))
             S2 = ee.ImageCollection('COPERNICUS/S2').filterDate(start,end).filterBounds(point)
             S2_list = S2.toList(S2.size().getInfo())
 
@@ -60,7 +60,7 @@ class HighResTiles(object):
 
             for x in range (0, S2.size().getInfo()):
 
-                d = S2_list.getInfo()[x] ##access asset id 
+                d = S2_list.getInfo()[x] ##access asset id
                 S2 = ee.Image(d.get('id'))
                 S2 = S2.divide(10000)  # Convert to Top of the atmosphere reflectance
                 S2 = S2.visualize(bands=["B4", "B3", "B2"], min=0, max=0.3, opacity=1.0)
@@ -74,13 +74,13 @@ class HighResTiles(object):
                 meta = HighResTiles.get_image_metadata2(d)
 
                 temp_output = {
-                        
+
                     'boundary_tiles': boundary_tiles,
                     'tile_url': image_tiles,
                     'thumbnail_url': thumbnail,
                     'metadata': meta,
                     'success': True
-                
+
                 }
 
                 output.append(temp_output)

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -155,7 +155,7 @@ class RecentTiles(object):
 
         try:
 
-            point = ee.Geometry.Point(float(lat), float(lon))
+            point = ee.Geometry.Point(float(lon), float(lat))
             S2 = ee.ImageCollection('COPERNICUS/S2').filterDate(start,end).filterBounds(point)
             L8 = ee.ImageCollection('LANDSAT/LC08/C01/T1_RT_TOA').filterDate(start,end).filterBounds(point)
 
@@ -166,7 +166,7 @@ class RecentTiles(object):
                 sentinel_image = c.get('properties').get('SPACECRAFT_NAME', None)
                 landsat_image = c.get('properties').get('SPACECRAFT_ID', None)
                 if sentinel_image:
-                     
+
                     date_info = c['id'].split('COPERNICUS/S2/')[1]
                     date_time = f"{date_info[0:4]}-{date_info[4:6]}-{date_info[6:8]} {date_info[9:11]}:{date_info[11:13]}:{date_info[13:15]}Z"
                     bbox = c['properties']['system:footprint']['coordinates']

--- a/gfwanalysis/services/analysis/sentinel_tiles.py
+++ b/gfwanalysis/services/analysis/sentinel_tiles.py
@@ -54,7 +54,7 @@ class SentinelTiles(object):
         end = '2017-03-01'
         """
         try:
-            point = ee.Geometry.Point(float(lat), float(lon))
+            point = ee.Geometry.Point(float(lon), float(lat))
             S2 = ee.ImageCollection('COPERNICUS/S2'
                                    ).filterDate(
                                     start, end).filterBounds(


### PR DESCRIPTION
The ee.Point() method was receiving lat/lon in the wrong order, so it meant that all calls to this service had to have been passing in lat/long miss-assigned for the services to work! Let's get this one fixed, and check that the recent services on GFW are functioning correctly...