### PR TITLE
Feat/sort recent sat

### DIFF
--- a/gfwanalysis/middleware.py
+++ b/gfwanalysis/middleware.py
@@ -70,7 +70,6 @@ def get_sentinel_params(func):
 def get_highres_params(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-
         if request.method == 'GET':
             lat = request.args.get('lat')
             lon = request.args.get('lon')
@@ -90,12 +89,12 @@ def get_highres_params(func):
 def get_recent_params(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-
         if request.method == 'GET':
             lat = request.args.get('lat')
             lon = request.args.get('lon')
             start = request.args.get('start')
             end = request.args.get('end')
+            sort_by = request.args.get('sort_by', None)
             bmin = request.args.get('min', None)
             bmax = request.args.get('max', None)
             opacity = request.args.get('opacity', 1.0)
@@ -106,6 +105,7 @@ def get_recent_params(func):
         kwargs["lon"] = lon
         kwargs["start"] = start
         kwargs["end"] = end
+        kwargs["sort_by"] = sort_by
         kwargs["bmin"] = bmin
         kwargs["bmax"] = bmax
         kwargs["opacity"] = float(opacity)

--- a/gfwanalysis/routes/api/v1/recent_router.py
+++ b/gfwanalysis/routes/api/v1/recent_router.py
@@ -19,7 +19,7 @@ from gfwanalysis.services.analysis.recent_tiles import RecentTiles
 recent_tiles_endpoints_v1 = Blueprint('recent_tiles_endpoints_v1', __name__)
 
 
-def analyze_recent_data(lat, lon, start, end, bands, bmin, bmax, opacity):
+def analyze_recent_data(lat, lon, start, end, sort_by, bands, bmin, bmax, opacity):
     """Returns metadata and *first* tile url from GEE for all Sentinel images
        in date range ('start'-'end') that intersect with lat,lon.
     #Example of valid inputs (for area focused on Tenerife)
@@ -31,7 +31,7 @@ def analyze_recent_data(lat, lon, start, end, bands, bmin, bmax, opacity):
     loop = asyncio.new_event_loop()
 
     try:
-        data = RecentTiles.recent_data(lat=lat, lon=lon, start=start, end=end)
+        data = RecentTiles.recent_data(lat=lat, lon=lon, start=start, end=end, sort_by=sort_by)
         data = loop.run_until_complete(RecentTiles.async_fetch(loop, RecentTiles.recent_tiles, data, bands, bmin, bmax, opacity, 'first'))
     except RecentTilesError as e:
         logging.error('[ROUTER]: ' + e.message)
@@ -78,10 +78,10 @@ def analyze_recent_thumbs(data_array, bands, bmin, bmax, opacity):
 
 @recent_tiles_endpoints_v1.route('/', strict_slashes=False, methods=['GET'])
 @get_recent_params
-def get_by_geostore(lat, lon, start, end, bands, bmin, bmax, opacity):
+def get_by_geostore(lat, lon, start, end, sort_by, bands, bmin, bmax, opacity):
     """Analyze by geostore"""
     logging.info('[ROUTER]: Getting data for tiles for Recent Sentinel Images')
-    data = analyze_recent_data(lat=lat, lon=lon, start=start, end=end, bands=bands, bmin=bmin, bmax=bmax, opacity=opacity)
+    data = analyze_recent_data(lat=lat, lon=lon, start=start, end=end, sort_by=sort_by, bands=bands, bmin=bmin, bmax=bmax, opacity=opacity)
     return data
 
 

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -156,7 +156,7 @@ class RecentTiles(object):
         return col_data
 
     @staticmethod
-    def recent_data(lat, lon, start, end):
+    def recent_data(lat, lon, start, end, sort_by):
         logging.info("[RECENT>DATA] function initiated")
         try:
             point = ee.Geometry.Point(float(lon), float(lat))
@@ -206,7 +206,10 @@ class RecentTiles(object):
                     }
                     data.append(tmp_)
             logging.info('[RECENT>DATA] sorting by cloud cover & date of acquisition')
-            sorted_data = sorted(data, key=lambda k: (k.get('date'), -k.get('cloud_score', 100)), reverse=True)
+            if sort_by and sort_by.lower() == 'cloud_score':
+                sorted_data = sorted(data, key=lambda k: (k.get('cloud_score', 100), k.get('date')), reverse=True)
+            else:
+                sorted_data = sorted(data, key=lambda k: (k.get('date'), -k.get('cloud_score', 100)), reverse=True)
             return sorted_data
         except:
             raise RecentTilesError('Recent Images service failed to return image.')


### PR DESCRIPTION
Adds a `sort_by` kwarg. Users can sort by `cloud_score` or `date` by default