### PR TITLE
Fix composite buffer failing for large shapes

### DIFF
--- a/gfwanalysis/services/analysis/composite_service.py
+++ b/gfwanalysis/services/analysis/composite_service.py
@@ -5,7 +5,7 @@ from shapely.geometry import shape, GeometryCollection
 from datetime import datetime, timedelta
 from gfwanalysis.errors import CompositeError
 from gfwanalysis.services.analysis.classification_service import create_model, add_indices, classify_image, get_classified_image_url
-from gfwanalysis.utils.geo import buffer_geom
+from gfwanalysis.utils.geo import buffer_geom, get_clip_vertex_list
 
 class CompositeService(object):
     """Gets a geostore geometry as input and returns a composite, cloud-free image within the geometry bounds.
@@ -36,6 +36,11 @@ class CompositeService(object):
                     width=2
                 ).visualize(bands=["constant"], palette=["C0FF24"], min=14, opacity=1.0)
                 region = buffer_geom(region)
+            else:
+                region = ee.Geometry({
+                    'type': 'Polygon',
+                    'coordinates': [get_clip_vertex_list(geojson)]
+                })
             date_range = CompositeService.get_formatted_date(date_range)
             sat_img = CompositeService.get_sat_img(instrument, region, date_range, cloudscore_thresh)
             if classify:

--- a/gfwanalysis/utils/geo.py
+++ b/gfwanalysis/utils/geo.py
@@ -17,8 +17,8 @@ def loop_future(loop, f, a):
         )
 
 def buffer_geom(geom):
-        buffer_size = geom.bounds(1).area(1).sqrt().multiply(0.5)
-        return geom.buffer(buffer_size).bounds(1)
+        buffer_size = geom.convexHull(1).bounds(1).area(1).sqrt().multiply(0.5)
+        return geom.convexHull(1).buffer(buffer_size).bounds(1)
 
 async def reverse_geocode_a_geostore(loop, shape):
     """ Take a shapely shape object and return geocoding results on the min/max coordinate locations"""


### PR DESCRIPTION
Fixes issue with large/complex composite images; in particular, multipolygons at adm1 and adm0 level.

Note, there are still some outstanding issues here - and the service does not perform well with very large or complex shapes (see Russia etc)