### PR TITLE
Feat/update umd loss gain service

### DIFF
--- a/gfwanalysis/config/base.py
+++ b/gfwanalysis/config/base.py
@@ -15,6 +15,7 @@ SETTINGS = {
         'service_account': '390573081381-lm51tabsc8q8b33ik497hc66qcmbj11d@developer.gserviceaccount.com',
         'privatekey_file': BASE_DIR + '/privatekey.pem',
         'assets': {
+            'hansen_optimised': 'projects/wri-datalab/global_forest_change_2018_v1_6_optimised',
             'hansen': 'projects/wri-datalab/HansenComposite_18',
             'hansen_2010_extent': 'projects/wri-datalab/HansenTreeCover2010',
             'hansen_2017_v1_5':'UMD/hansen/global_forest_change_2017_v1_5',

--- a/gfwanalysis/routes/api/v1/hansen_router.py
+++ b/gfwanalysis/routes/api/v1/hansen_router.py
@@ -39,10 +39,11 @@ def analyze(geojson, area_ha):
         logging.error('[ROUTER]: ' + e.message)
         return error(status=500, detail=e.message)
     except Exception as e:
-        logging.error('[ROUTER]: ' + str(e))
+        logging.error(f"[ROUTER]: {e}")
         return error(status=500, detail='Generic Error')
 
     data['area_ha'] = area_ha
+    logging.error(f"[ROUTER]: dict returned {data}")
     if table and not aggregate_values:
         return jsonify(data=serialize_table_umd(data, 'umd')), 200
     else:

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -10,8 +10,8 @@ def serialize_umd(analysis, type):
         'attributes': {
             'loss': analysis.get('loss', None),
             'gain': analysis.get('gain', None),
-            'treeExtent': analysis.get('tree_extent', None),
-            'treeExtent2010': analysis.get('tree_extent2010', None),
+            'treeExtent': analysis.get('treeExtent', None),
+            'treeExtent2010': analysis.get('treeExtent2010', None),
             'areaHa': analysis.get('area_ha', None),
             'loss_start_year': analysis.get('loss_start_year', None),
             'loss_end_year': analysis.get('loss_end_year', None)
@@ -34,7 +34,7 @@ def serialize_composite_output(analysis, type):
         'id': None,
         'type': type,
         'attributes': {
-            'thumb_url': analysis.get('thumb_url', None), 
+            'thumb_url': analysis.get('thumb_url', None),
             'tile_url':analysis.get('tile_url', None),
             'dem':analysis.get('dem', None),
             'zonal_stats':analysis.get('zonal_stats', None)
@@ -49,8 +49,8 @@ def serialize_table_umd(analysis, type):
                      'loss': analysis.get('loss', None).get(year),
                      'gain': analysis.get('gain', None),
                      'areaHa': analysis.get('area_ha', None),
-                     'treeExtent': analysis.get('tree_extent', None),
-                     'treeExtent2010': analysis.get('tree_extent2010', None),
+                     'treeExtent': analysis.get('treeExtent', None),
+                     'treeExtent2010': analysis.get('treeExtent2010', None),
                      })
     return {
         'id': None,

--- a/gfwanalysis/services/analysis/hansen_service.py
+++ b/gfwanalysis/services/analysis/hansen_service.py
@@ -11,79 +11,196 @@ from gfwanalysis.utils.geo import get_region, squaremeters_to_ha
 class HansenService(object):
 
     @staticmethod
-    def analyze(threshold, geojson, begin, end, aggregate_values=True):
-        """For a given threshold and geometry return a dictionary of ha area.
-        The threshold is used to identify which band of loss and tree to select.
-        asset_id should be 'projects/wri-datalab/HansenComposite_14-15'
-        Methods used to identify data:
+    def analyze(threshold, geojson, begin, end, aggregate_values=True, n_divisions='n4', method='reduce_regions', numPixels=10000, bestEffort=False):
+    """For a given threshold, geometry, start and end date, apply a GEE method
+    to calculate the total area (Ha) of tree cover in the year 2000 and 2010, 
+    the gain in tree cover between 2000 and 2012, and either the time-aggregated
+    or annual tree cover loss within the geometry. This analysis requires a 
+    pre generated optimised gee asset (hansen_optimised) to be created that 
+    converts the latest Hansen tree cover loss and tree cover in 2010 products 
+    into binary rasters.  
 
-        Gain band is a binary (0 = 0, 255=1) of locations where tree cover increased
-        over data collction period. Calculate area of gain, by converting 255 values
-        to 1, and then using a trick to convert this to pixel area
-        (1 * pixelArea()). Finally, we sum the areas over a given polygon using a
-        reducer, and convert from square meters to hectares.
+    # Arguments
+    
+    threshold -- The threshold for % tree cover in the year 2000, used to mask 
+                 treecover2000, treecover2010, and lossyear.
+    geojson -- A valid geojson object.
+    begin -- The start date for the analysis ('YYYY-MM-DD').
+    end -- The end date for the analysis ('YYYY-MM-DD').
+    aggregate_values -- Return the total aggregated loss during time period or 
+                        annual loss ('True).
+    n_divisions -- Divide the geometry into n parts, apply analysis to each part
+                   and return the total. 'n0' does no divisions, ('n4', 'n16', 
+                   'n32', 'n64'). Note for complex analysis too many divisions 
+                   can give GEE errors.
+    method -- Which method is used to calculate area; 'reduce_regions' apply the
+              .reduceRegions method to the geometry FeatureCollection, 
+              'reduce_region_map' map .reduceRegion over the geometry 
+              FeatureCollection, sample_region_map' map .sample over the 
+              geometry FeatureCollection.
+    numPixels -- The total number of pixels to sample when using 
+                 'map_sample', note this is divided between splits.
+    bestEffort -- Use the 'bestEffort=True' option when using 'map_reduce'. Note
+                  care should be taken to ensure the bands pyramid policy 
+                  matches the data type (after transformation) to avoid errors 
+                  of upto 20%.                                                  
+    """
+    try:
+        logging.info("Starting hansen analysis")
+        
+        # initialise GEE
+        ee.Initialize()
+        
+        # Set constants for the analysis
+        # make all objects SERVER
+          # returns ee.Number
+        numPixels = ee.Number(numPixels).long()
+        threshold = ee.Number(threshold)
+        begin = ee.Number.parse(ee.Date(begin).format('yy').slice(0,2))
+        end = ee.Number.parse(ee.Date(end).format('yy').slice(0,2))
+          # returns ee.String
+        n_divisions = ee.String(n_divisions)
+        lossyear_band = ee.String('lossyear_').cat(threshold.format())
+        treecover2000_band = ee.String('treecover2000_').cat(threshold.format())
+        treecover2010_band = ee.String('treecover2010_').cat(threshold.format())
+        gain20002012_band = ee.String('gain20002012_').cat(threshold.format())
+        asset_id = ee.String(SETTINGS.get('gee').get('assets').get('hansen_optimised'))
+        
+        # Get the feature collection of geometries
+          # returns ee.FeatureCollection
+        region_nosplit = get_region(geojson)
+        logging.info("Got the feature collection of geometries")
+        
+        # Optionally divide each of the fc's geoms by nX and return fc.
+          # returns ee.FeatureCollection
+        def divide_geometry_ntimes(feature, n_divisions = n_divisions):
+          fc4 = ee.FeatureCollection(divide_geometry(feature))
+          fc16 = ee.FeatureCollection(fc4.map(divide_geometry)).flatten()
+          fc64 = ee.FeatureCollection(fc16.map(divide_geometry)).flatten()
+          fc256 = ee.FeatureCollection(fc64.map(divide_geometry)).flatten()
+          out = ee.Dictionary({ \
+                      'n0': ee.FeatureCollection(feature), \
+                      'n4': fc4, \
+                      'n16': fc16, \
+                      'n64': fc64, \
+                      'n256': fc256, \
+                      })
+          return ee.FeatureCollection(out.get(n_divisions))
+        region_split = ee.FeatureCollection(region_nosplit).map(divide_geometry_ntimes).flatten()
+        logging.info("Divided the feature collection of geometries")
+        
+        # Choose if to split region
+        # Note code for region_split OR region_nosplit is called depending
+        # value of Boolean split_geometry=True
+          # returns ee.FeatureCollection
+        region_fc = ee.Algorithms.If(n_divisions, region_split, region_nosplit)
+        n_features = ee.Number(ee.FeatureCollection(region_fc).size())
+        logging.info('Number of features is' + n_features.getInfo())
+        def get_area(f):
+          return ee.Feature(None, {
+              'area_ha': ee_squaremeters_to_ha(f.geometry().area()),
+               'px': f.geometry().area().divide(30.0)})
+        area_feature = ee.FeatureCollection(region_fc).map(get_area)
+        total_area = area_feature.aggregate_sum('area_ha')  
+        logging.info('Total area (Ha) is' + total_area.getInfo())
+        logging.info('Area (Ha) per feature is' + area_feature.aggregate_array('area_ha').getInfo())
+        logging.info('Pixels per feature is' + area_feature.aggregate_array('px').getInfo())
+        # if split_geometry divide numPixels by number of splits
+        numPixels = ee.Algorithms.If(n_divisions, ee.Number(numPixels).divide(n_features).long(), numPixels)
+        logging.info("Divided the feature collection of geometries")
 
-        Tree_X bands show percentage canopy cover of forest, If missing, no trees
-        present. Therefore, to count the tree area of a given canopy cover, select
-        the band, convert it to binary (0=no tree cover, 1 = tree cover), and
-        identify pixel area via a trick, multiplying all 1 vals by image.pixelArea.
-        Then, sum the values over a region. Finally, divide the result (meters
-        squared) by 10,000 to convert to hectares
-        """
-        try:
-            d = {}
-            asset_id = SETTINGS.get('gee').get('assets').get('hansen')
-            extent_2010_asset = SETTINGS.get('gee').get('assets').get('hansen_2010_extent')
-            hansen_v1_5_asset = SETTINGS.get('gee').get('assets').get('hansen_2017_v1_5')
-            begin = int(begin.split('-')[0][2:])
-            end = int(end.split('-')[0][2:])
-            d['loss_start_year'] = begin
-            d['loss_end_year'] = end
-            region = get_region(geojson)
-            reduce_args = {'reducer': ee.Reducer.sum().unweighted(),
-                           'geometry': region,
-                           'bestEffort': False,
-                           'scale': 30,
-                           'tileScale': 16,
-                           'maxPixels': 1e12}
-            gfw_data = ee.Image(asset_id)
-            hansen_v1_5 = ee.Image(hansen_v1_5_asset)
-            loss_band = 'loss_{0}'.format(threshold)
-            cover_band = 'tree_{0}'.format(threshold)
-            # Identify 2000 forest cover at given threshold
-            tree_area = hansen_v1_5.select('treecover2000').gt(float(threshold)).multiply(
-                ee.Image.pixelArea()).reduceRegion(**reduce_args).getInfo()
-            d['tree_extent'] = squaremeters_to_ha(tree_area['treecover2000'])
-            # Identify 2010 forest cover at given threshold
-            extent2010_image = ee.Image(extent_2010_asset)
-            extent2010_area = extent2010_image.gt(float(threshold)).multiply(
-                ee.Image.pixelArea()).reduceRegion(**reduce_args).getInfo()
-            d['tree_extent2010'] = squaremeters_to_ha(extent2010_area['b1'])
-            # Identify tree gain over data collection period
-            gain = gfw_data.select('gain').divide(255.0).multiply(
-                ee.Image.pixelArea()).reduceRegion(**reduce_args).getInfo()
-            d['gain'] = squaremeters_to_ha(gain['gain'])
-            # Mask loss with itself to avoid overcounting errors
-            tmp_img = gfw_data.select(loss_band).mask(gfw_data.select(loss_band))
-            if aggregate_values:
-                # Identify one loss area from begin year up untill end year
-                loss_area_img = tmp_img.gte(begin).And(tmp_img.lte(end)).multiply(ee.Image.pixelArea())
-                loss_total = loss_area_img.reduceRegion(**reduce_args).getInfo()
-                d['loss'] = squaremeters_to_ha(loss_total[loss_band])
-            else:
-                # Identify loss area per year from beginning year to end year (inclusive)
-                def reduceFunction(img):
-                    out = img.reduceRegion(**reduce_args)
-                    return ee.Feature(None, out)
+        # Get the optimised hansen asset
+        # these are all binary bands, except lossyear
+        hansen_optimised = ee.Image(asset_id)
 
-                ## Calculate annual biomass loss - add subset images to a collection and then map a reducer to it
-                collectionG = ee.ImageCollection([tmp_img.updateMask(tmp_img.eq(year)).divide(year).multiply(
-                    ee.Image.pixelArea()).set({'year': 2000 + year}) for year in range(begin, end + 1)])
-                output = collectionG.map(reduceFunction).getInfo()
-                d['loss'] = {}
-                for row, yr in zip(output.get('features'), range(begin, end + 1)):
-                    d['loss'][yr + 2000] = squaremeters_to_ha(row.get('properties').get(loss_band))
-            return d
-        except Exception as error:
-            logging.error(str(error))
-            raise HansenError(message='Error in Hansen Analysis')
+        # Identify year 2000 tree cover at given threshold
+          # returns ee.Image
+        treecover2000_image = ee.Image(hansen_optimised.select(treecover2000_band))
+        treecover2000_image = treecover2000_image.updateMask(treecover2000_image)
+          # returns ee.Number
+        extent2000 = get_extent_fc(treecover2000_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+        extent2000 = ee_squaremeters_to_ha(extent2000)
+        logging.info("Calculated tree cover extent in year 2000")
+        
+        # Identify 2010 tree cover at given threshold
+          # returns ee.Image
+        treecover2010_image = ee.Image(hansen_optimised.select(treecover2010_band))
+        treecover2010_image = treecover2010_image.updateMask(treecover2010_image)
+          # returns ee.Number
+        extent2010 = get_extent_fc(treecover2010_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+        extent2010 = ee_squaremeters_to_ha(extent2010)
+        logging.info("Calculated tree cover extent in year 2010")
+        
+        # Identify tree gain over data collection period
+          # returns ee.Image
+        # NOTE GAIN IS NOT THRESHOLDED BY TREECOVER2000!
+        # FIXME IT MAKES NO SENSE TO EXPORT THRESHOLDED GAIN!
+        gain20002012_image = ee.Image(hansen_optimised.select('gain20002012_0'))
+        gain20002012_image = gain20002012_image.updateMask(gain20002012_image)
+          # returns ee.Number
+        gain = get_extent_fc(gain20002012_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+        gain = ee_squaremeters_to_ha(gain)
+        logging.info("Calculated tree cover gain between 2000 and 2012")
+        
+        # Identify loss
+          # returns ee.Image
+        lossyear_image = ee.Image(hansen_optimised.select(lossyear_band))
+        lossyear_image = lossyear_image.updateMask(lossyear_image)
+        # Select loss pixels from begin year till end year (0-18)
+          # returns ee.Image
+        loss_image_ag = lossyear_image.gte(begin).And(lossyear_image.lte(end))
+          # returns ee.Number
+        loss_ag = get_extent_fc(loss_image_ag, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+        loss_ag = ee_squaremeters_to_ha(loss_ag)
+        logging.info("Calculated aggregated tree cover loss in period")
+        
+        logging.info("Begin calculating yearly tree cover loss during period")
+        # Identify loss area per year from beginning year to end year (inclusive)
+        # Calculate annual biomass loss - add subset images to a collection 
+        # and then map a reducer over image collection
+          # returns ee.List()
+        year_list = ee.List.sequence(begin, end, 1)
+          # returns ee.ImageCollection
+        def tmp_f(year):
+                year = ee.Number(year)
+                return lossyear_image \
+                .updateMask(lossyear_image.eq(ee.Image.constant(year))) \
+                .divide(year) \
+                .set({'year': ee.Number(2000).add(year)})
+        yearly_loss_collection = ee.ImageCollection(year_list.map(tmp_f))
+        logging.info("Created annual biomass loss image collection")
+          # returns ee.FeatureCollection
+        def reduceFunction(img):
+            out = get_extent_fc(img, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+            out = ee_squaremeters_to_ha(out)
+            year = ee.Number(img.get('year')).format('%.0f')
+            return ee.Feature(None, {'year': year, 'loss': out})
+        output = yearly_loss_collection.map(reduceFunction)
+          # returns ee.Dictionary
+        loss_years = ee.Dictionary.fromLists( \
+            output.aggregate_array('year'), \
+            output.aggregate_array('loss'))
+        logging.info("Calculated yearly tree cover loss during period")    
+        
+        # Choose which loss type to return
+        # Note code for loss_ag OR loss_years is called depending
+        # value of Boolean aggregate_values=True
+        loss = ee.Algorithms.If(aggregate_values, loss_ag, loss_years)
+
+        # Create dictionary of results
+        # ee.Dictionary
+        d = ee.Dictionary({
+            'areaHa' : total_area, 
+            'loss_start_year' : begin,
+            'loss_end_year' : end,
+            'treeExtent' : extent2000,
+            'treeExtent2010' : extent2010,
+            'gain' : gain,
+            'loss' : loss
+            
+        })
+        # Evaluate the dictionary of results
+        return d.getInfo()
+    except Exception as error:
+        logging.error(str(error))
+        raise HansenError(message='Error in Hansen Analysis')

--- a/gfwanalysis/services/analysis/hansen_service.py
+++ b/gfwanalysis/services/analysis/hansen_service.py
@@ -134,7 +134,7 @@ class HansenService(object):
         # returns ee.Number
       gain = get_extent_fc(gain20002012_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
       gain = ee_squaremeters_to_ha(gain)
-      logging.info(f"Calculated tree cover gain between 2000 and 2012: {type(gain)}")
+      logging.info(f"Calculated tree cover gain between 2000 and 2012:")
 
       # Identify loss
         # returns ee.Image
@@ -180,7 +180,6 @@ class HansenService(object):
       # Note code for loss_ag OR loss_years is called depending
       # value of Boolean aggregate_values=True
       loss = ee.Algorithms.If(aggregate_values, loss_ag, loss_years)
-      logging.info(f"blah: {extent2000}")
       # Create dictionary of results
       # ee.Dictionary
       d = ee.Dictionary({
@@ -194,7 +193,8 @@ class HansenService(object):
 
       })
       # Evaluate the dictionary of results
-      return d.getInfo()
+      tmp_d = d.getInfo()
+      return tmp_d
     except Exception as error:
         logging.error(str(error))
         raise HansenError(message='Error in Hansen Analysis')

--- a/gfwanalysis/services/analysis/hansen_service.py
+++ b/gfwanalysis/services/analysis/hansen_service.py
@@ -9,198 +9,200 @@ from gfwanalysis.utils.geo import get_region, ee_squaremeters_to_ha, get_extent_
 
 
 class HansenService(object):
-
-    @staticmethod
-    def analyze(threshold, geojson, begin, end, aggregate_values=True, n_divisions='n4', method='reduce_regions', numPixels=10000, bestEffort=False):
-    """For a given threshold, geometry, start and end date, apply a GEE method
-    to calculate the total area (Ha) of tree cover in the year 2000 and 2010, 
+  """For a given threshold, geometry, start and end date, apply a GEE method
+    to calculate the total area (Ha) of tree cover in the year 2000 and 2010,
     the gain in tree cover between 2000 and 2012, and either the time-aggregated
-    or annual tree cover loss within the geometry. This analysis requires a 
-    pre generated optimised gee asset (hansen_optimised) to be created that 
-    converts the latest Hansen tree cover loss and tree cover in 2010 products 
-    into binary rasters.  
+    or annual tree cover loss within the geometry. This analysis requires a
+    pre generated optimised gee asset (hansen_optimised) to be created that
+    converts the latest Hansen tree cover loss and tree cover in 2010 products
+    into binary rasters.
 
     # Arguments
-    
-    threshold -- The threshold for % tree cover in the year 2000, used to mask 
+
+    threshold -- The threshold for % tree cover in the year 2000, used to mask
                  treecover2000, treecover2010, and lossyear.
     geojson -- A valid geojson object.
     begin -- The start date for the analysis ('YYYY-MM-DD').
     end -- The end date for the analysis ('YYYY-MM-DD').
-    aggregate_values -- Return the total aggregated loss during time period or 
+    aggregate_values -- Return the total aggregated loss during time period or
                         annual loss ('True).
     n_divisions -- Divide the geometry into n parts, apply analysis to each part
-                   and return the total. 'n0' does no divisions, ('n4', 'n16', 
-                   'n32', 'n64'). Note for complex analysis too many divisions 
+                   and return the total. 'n0' does no divisions, ('n4', 'n16',
+                   'n32', 'n64'). Note for complex analysis too many divisions
                    can give GEE errors.
     method -- Which method is used to calculate area; 'reduce_regions' apply the
-              .reduceRegions method to the geometry FeatureCollection, 
-              'reduce_region_map' map .reduceRegion over the geometry 
-              FeatureCollection, sample_region_map' map .sample over the 
+              .reduceRegions method to the geometry FeatureCollection,
+              'reduce_region_map' map .reduceRegion over the geometry
+              FeatureCollection, sample_region_map' map .sample over the
               geometry FeatureCollection.
-    numPixels -- The total number of pixels to sample when using 
+    numPixels -- The total number of pixels to sample when using
                  'map_sample', note this is divided between splits.
     bestEffort -- Use the 'bestEffort=True' option when using 'map_reduce'. Note
-                  care should be taken to ensure the bands pyramid policy 
-                  matches the data type (after transformation) to avoid errors 
-                  of upto 20%.                                                  
+                  care should be taken to ensure the bands pyramid policy
+                  matches the data type (after transformation) to avoid errors
+                  of upto 20%.
     """
+
+
+  @staticmethod
+  def get_area(f):
+    return ee.Feature(None, {
+                              'area_ha': ee_squaremeters_to_ha(f.geometry().area()),
+                              'px': f.geometry().area().divide(30.0)
+                              })
+
+  @staticmethod
+  def reduceFunction(img):
+      out = get_extent_fc(img, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+      out = ee_squaremeters_to_ha(out)
+      year = ee.Number(img.get('year')).format('%.0f')
+      return ee.Feature(None, {'year': year, 'loss': out})
+
+  @staticmethod
+  def analyze(threshold, geojson, begin, end, aggregate_values=True,
+              n_divisions='n4', method='reduce_regions', numPixels=10000, bestEffort=False):
     try:
-        logging.info("Starting hansen analysis")
-        
-        # initialise GEE
-        ee.Initialize()
-        
-        # Set constants for the analysis
-        # make all objects SERVER
-          # returns ee.Number
-        numPixels = ee.Number(numPixels).long()
-        threshold = ee.Number(threshold)
-        begin = ee.Number.parse(ee.Date(begin).format('yy').slice(0,2))
-        end = ee.Number.parse(ee.Date(end).format('yy').slice(0,2))
-          # returns ee.String
-        n_divisions = ee.String(n_divisions)
-        lossyear_band = ee.String('lossyear_').cat(threshold.format())
-        treecover2000_band = ee.String('treecover2000_').cat(threshold.format())
-        treecover2010_band = ee.String('treecover2010_').cat(threshold.format())
-        gain20002012_band = ee.String('gain20002012_').cat(threshold.format())
-        asset_id = ee.String(SETTINGS.get('gee').get('assets').get('hansen_optimised'))
-        
-        # Get the feature collection of geometries
-          # returns ee.FeatureCollection
-        region_nosplit = get_region(geojson)
-        logging.info("Got the feature collection of geometries")
-        
-        # Optionally divide each of the fc's geoms by nX and return fc.
-          # returns ee.FeatureCollection
-        def divide_geometry_ntimes(feature, n_divisions = n_divisions):
-          fc4 = ee.FeatureCollection(divide_geometry(feature))
-          fc16 = ee.FeatureCollection(fc4.map(divide_geometry)).flatten()
-          fc64 = ee.FeatureCollection(fc16.map(divide_geometry)).flatten()
-          fc256 = ee.FeatureCollection(fc64.map(divide_geometry)).flatten()
-          out = ee.Dictionary({ \
-                      'n0': ee.FeatureCollection(feature), \
-                      'n4': fc4, \
-                      'n16': fc16, \
-                      'n64': fc64, \
-                      'n256': fc256, \
-                      })
-          return ee.FeatureCollection(out.get(n_divisions))
-        region_split = ee.FeatureCollection(region_nosplit).map(divide_geometry_ntimes).flatten()
-        logging.info("Divided the feature collection of geometries")
-        
-        # Choose if to split region
-        # Note code for region_split OR region_nosplit is called depending
-        # value of Boolean split_geometry=True
-          # returns ee.FeatureCollection
-        region_fc = ee.Algorithms.If(n_divisions, region_split, region_nosplit)
-        n_features = ee.Number(ee.FeatureCollection(region_fc).size())
-        logging.info('Number of features is' + n_features.getInfo())
-        def get_area(f):
-          return ee.Feature(None, {
-              'area_ha': ee_squaremeters_to_ha(f.geometry().area()),
-               'px': f.geometry().area().divide(30.0)})
-        area_feature = ee.FeatureCollection(region_fc).map(get_area)
-        total_area = area_feature.aggregate_sum('area_ha')  
-        logging.info('Total area (Ha) is' + total_area.getInfo())
-        logging.info('Area (Ha) per feature is' + area_feature.aggregate_array('area_ha').getInfo())
-        logging.info('Pixels per feature is' + area_feature.aggregate_array('px').getInfo())
-        # if split_geometry divide numPixels by number of splits
-        numPixels = ee.Algorithms.If(n_divisions, ee.Number(numPixels).divide(n_features).long(), numPixels)
-        logging.info("Divided the feature collection of geometries")
+      logging.info("Starting hansen analysis")
+      # Set constants for the analysis
+      # make all objects SERVER
+      # returns ee.Number
+      numPixels = ee.Number(numPixels).long()
+      threshold = ee.Number(threshold)
+      begin = ee.Number.parse(ee.Date(begin).format('yy').slice(0,2))
+      end = ee.Number.parse(ee.Date(end).format('yy').slice(0,2))
+      # returns ee.String
+      n_divisions = ee.String(n_divisions)
+      lossyear_band = ee.String('lossyear_').cat(threshold.format())
+      treecover2000_band = ee.String('treecover2000_').cat(threshold.format())
+      treecover2010_band = ee.String('treecover2010_').cat(threshold.format())
+      gain20002012_band = ee.String('gain20002012_').cat(threshold.format())
+      asset_id = ee.String(SETTINGS.get('gee').get('assets').get('hansen_optimised'))
+      # Get the feature collection of geometries
+      # returns ee.FeatureCollection
+      region_nosplit = get_region(geojson)
+      logging.info("Got the feature collection of geometries")
+      def divide_geometry_ntimes(feature, n_divisions = n_divisions):
+        """
+          Optionally divide each of the fc's geoms by nX and return fc.
+          returns ee.FeatureCollection
+        """
+        fc4 = ee.FeatureCollection(divide_geometry(feature))
+        fc16 = ee.FeatureCollection(fc4.map(divide_geometry)).flatten()
+        fc64 = ee.FeatureCollection(fc16.map(divide_geometry)).flatten()
+        fc256 = ee.FeatureCollection(fc64.map(divide_geometry)).flatten()
+        out = ee.Dictionary({
+                            'n0': ee.FeatureCollection(feature),
+                            'n4': fc4,
+                            'n16': fc16,
+                            'n64': fc64,
+                            'n256': fc256,
+                            })
+        return ee.FeatureCollection(out.get(n_divisions))
+      region_split = ee.FeatureCollection(region_nosplit).map(divide_geometry_ntimes).flatten()
+      logging.info("Divided the feature collection of geometries")
+      # Choose if to split region
+      # Note code for region_split OR region_nosplit is called depending
+      # value of Boolean split_geometry=True
+      # returns ee.FeatureCollection
+      region_fc = ee.Algorithms.If(n_divisions, region_split, region_nosplit)
+      n_features = ee.Number(ee.FeatureCollection(region_fc).size())
+      logging.info(f'Number of features is {n_features.getInfo()}')
+      area_feature = ee.FeatureCollection(region_fc).map(get_area)
+      total_area = area_feature.aggregate_sum('area_ha')
+      logging.info(f"Total area (Ha) is {total_area.getInfo()}")
+      logging.info(f"Area (Ha) per feature is {area_feature.aggregate_array('area_ha').getInfo()}")
+      logging.info(f"Pixels per feature is {area_feature.aggregate_array('px').getInfo()}")
+      # if split_geometry divide numPixels by number of splits
+      numPixels = ee.Algorithms.If(n_divisions, ee.Number(numPixels).divide(n_features).long(), numPixels)
+      logging.info("Divided the feature collection of geometries")
+      # Get the optimised hansen asset
+      # these are all binary bands, except lossyear
+      hansen_optimised = ee.Image(asset_id)
 
-        # Get the optimised hansen asset
-        # these are all binary bands, except lossyear
-        hansen_optimised = ee.Image(asset_id)
+      # Identify year 2000 tree cover at given threshold
+        # returns ee.Image
+      treecover2000_image = ee.Image(hansen_optimised.select(treecover2000_band))
+      treecover2000_image = treecover2000_image.updateMask(treecover2000_image)
+        # returns ee.Number
+      extent2000 = get_extent_fc(treecover2000_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+      extent2000 = ee_squaremeters_to_ha(extent2000)
+      logging.info("Calculated tree cover extent in year 2000")
 
-        # Identify year 2000 tree cover at given threshold
-          # returns ee.Image
-        treecover2000_image = ee.Image(hansen_optimised.select(treecover2000_band))
-        treecover2000_image = treecover2000_image.updateMask(treecover2000_image)
-          # returns ee.Number
-        extent2000 = get_extent_fc(treecover2000_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
-        extent2000 = ee_squaremeters_to_ha(extent2000)
-        logging.info("Calculated tree cover extent in year 2000")
-        
-        # Identify 2010 tree cover at given threshold
-          # returns ee.Image
-        treecover2010_image = ee.Image(hansen_optimised.select(treecover2010_band))
-        treecover2010_image = treecover2010_image.updateMask(treecover2010_image)
-          # returns ee.Number
-        extent2010 = get_extent_fc(treecover2010_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
-        extent2010 = ee_squaremeters_to_ha(extent2010)
-        logging.info("Calculated tree cover extent in year 2010")
-        
-        # Identify tree gain over data collection period
-          # returns ee.Image
-        # NOTE GAIN IS NOT THRESHOLDED BY TREECOVER2000!
-        # FIXME IT MAKES NO SENSE TO EXPORT THRESHOLDED GAIN!
-        gain20002012_image = ee.Image(hansen_optimised.select('gain20002012_0'))
-        gain20002012_image = gain20002012_image.updateMask(gain20002012_image)
-          # returns ee.Number
-        gain = get_extent_fc(gain20002012_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
-        gain = ee_squaremeters_to_ha(gain)
-        logging.info("Calculated tree cover gain between 2000 and 2012")
-        
-        # Identify loss
-          # returns ee.Image
-        lossyear_image = ee.Image(hansen_optimised.select(lossyear_band))
-        lossyear_image = lossyear_image.updateMask(lossyear_image)
-        # Select loss pixels from begin year till end year (0-18)
-          # returns ee.Image
-        loss_image_ag = lossyear_image.gte(begin).And(lossyear_image.lte(end))
-          # returns ee.Number
-        loss_ag = get_extent_fc(loss_image_ag, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
-        loss_ag = ee_squaremeters_to_ha(loss_ag)
-        logging.info("Calculated aggregated tree cover loss in period")
-        
-        logging.info("Begin calculating yearly tree cover loss during period")
-        # Identify loss area per year from beginning year to end year (inclusive)
-        # Calculate annual biomass loss - add subset images to a collection 
-        # and then map a reducer over image collection
-          # returns ee.List()
-        year_list = ee.List.sequence(begin, end, 1)
-          # returns ee.ImageCollection
-        def tmp_f(year):
-                year = ee.Number(year)
-                return lossyear_image \
-                .updateMask(lossyear_image.eq(ee.Image.constant(year))) \
-                .divide(year) \
-                .set({'year': ee.Number(2000).add(year)})
-        yearly_loss_collection = ee.ImageCollection(year_list.map(tmp_f))
-        logging.info("Created annual biomass loss image collection")
-          # returns ee.FeatureCollection
-        def reduceFunction(img):
-            out = get_extent_fc(img, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
-            out = ee_squaremeters_to_ha(out)
-            year = ee.Number(img.get('year')).format('%.0f')
-            return ee.Feature(None, {'year': year, 'loss': out})
-        output = yearly_loss_collection.map(reduceFunction)
-          # returns ee.Dictionary
-        loss_years = ee.Dictionary.fromLists( \
-            output.aggregate_array('year'), \
-            output.aggregate_array('loss'))
-        logging.info("Calculated yearly tree cover loss during period")    
-        
-        # Choose which loss type to return
-        # Note code for loss_ag OR loss_years is called depending
-        # value of Boolean aggregate_values=True
-        loss = ee.Algorithms.If(aggregate_values, loss_ag, loss_years)
+      # Identify 2010 tree cover at given threshold
+        # returns ee.Image
+      treecover2010_image = ee.Image(hansen_optimised.select(treecover2010_band))
+      treecover2010_image = treecover2010_image.updateMask(treecover2010_image)
+        # returns ee.Number
+      extent2010 = get_extent_fc(treecover2010_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+      extent2010 = ee_squaremeters_to_ha(extent2010)
+      logging.info("Calculated tree cover extent in year 2010")
 
-        # Create dictionary of results
-        # ee.Dictionary
-        d = ee.Dictionary({
-            'areaHa' : total_area, 
-            'loss_start_year' : begin,
-            'loss_end_year' : end,
-            'treeExtent' : extent2000,
-            'treeExtent2010' : extent2010,
-            'gain' : gain,
-            'loss' : loss
-            
-        })
-        # Evaluate the dictionary of results
-        return d.getInfo()
+      # Identify tree gain over data collection period
+        # returns ee.Image
+      # NOTE GAIN IS NOT THRESHOLDED BY TREECOVER2000!
+      # FIXME IT MAKES NO SENSE TO EXPORT THRESHOLDED GAIN!
+      gain20002012_image = ee.Image(hansen_optimised.select('gain20002012_0'))
+      gain20002012_image = gain20002012_image.updateMask(gain20002012_image)
+        # returns ee.Number
+      gain = get_extent_fc(gain20002012_image, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+      gain = ee_squaremeters_to_ha(gain)
+      logging.info("Calculated tree cover gain between 2000 and 2012")
+
+      # Identify loss
+        # returns ee.Image
+      lossyear_image = ee.Image(hansen_optimised.select(lossyear_band))
+      lossyear_image = lossyear_image.updateMask(lossyear_image)
+      # Select loss pixels from begin year till end year (0-18)
+        # returns ee.Image
+      loss_image_ag = lossyear_image.gte(begin).And(lossyear_image.lte(end))
+        # returns ee.Number
+      loss_ag = get_extent_fc(loss_image_ag, region_fc, method=method, bestEffort=bestEffort, scale=False, numPixels=numPixels)
+      loss_ag = ee_squaremeters_to_ha(loss_ag)
+      logging.info("Calculated aggregated tree cover loss in period")
+
+      logging.info("Begin calculating yearly tree cover loss during period")
+      # Identify loss area per year from beginning year to end year (inclusive)
+      # Calculate annual biomass loss - add subset images to a collection
+      # and then map a reducer over image collection
+        # returns ee.List()
+      year_list = ee.List.sequence(begin, end, 1)
+      # returns ee.ImageCollection
+      def tmp_f(year):
+              year = ee.Number(year)
+              return lossyear_image \
+              .updateMask(lossyear_image.eq(ee.Image.constant(year))) \
+              .divide(year) \
+              .set({'year': ee.Number(2000).add(year)})
+      yearly_loss_collection = ee.ImageCollection(year_list.map(tmp_f))
+      logging.info("Created annual biomass loss image collection")
+        # returns ee.FeatureCollection
+
+      output = yearly_loss_collection.map(reduceFunction)
+        # returns ee.Dictionary
+      loss_years = ee.Dictionary.fromLists( \
+          output.aggregate_array('year'), \
+          output.aggregate_array('loss'))
+      logging.info("Calculated yearly tree cover loss during period")
+
+      # Choose which loss type to return
+      # Note code for loss_ag OR loss_years is called depending
+      # value of Boolean aggregate_values=True
+      loss = ee.Algorithms.If(aggregate_values, loss_ag, loss_years)
+
+      # Create dictionary of results
+      # ee.Dictionary
+      d = ee.Dictionary({
+          'areaHa' : total_area,
+          'loss_start_year' : begin,
+          'loss_end_year' : end,
+          'treeExtent' : extent2000,
+          'treeExtent2010' : extent2010,
+          'gain' : gain,
+          'loss' : loss
+
+      })
+      # Evaluate the dictionary of results
+      return d.getInfo()
     except Exception as error:
         logging.error(str(error))
         raise HansenError(message='Error in Hansen Analysis')

--- a/gfwanalysis/services/analysis/hansen_service.py
+++ b/gfwanalysis/services/analysis/hansen_service.py
@@ -5,7 +5,7 @@ import logging
 
 from gfwanalysis.config import SETTINGS
 from gfwanalysis.errors import HansenError
-from gfwanalysis.utils.geo import get_region, squaremeters_to_ha
+from gfwanalysis.utils.geo import get_region, ee_squaremeters_to_ha, get_extent_fc
 
 
 class HansenService(object):

--- a/gfwanalysis/utils/geo.py
+++ b/gfwanalysis/utils/geo.py
@@ -5,6 +5,171 @@ import geocoder
 import asyncio
 import functools as funct
 
+def get_extent_fc(image, fc, method='reduce_regions', bestEffort=False, scale=False, numPixels=10000):
+  """ Given an ee.featureCollection (fc) of features each with
+  a single geometry calculate the total extent (area_m2) using
+  a single band binary image. The single band binary image is 
+  multiplied by pixel area, ee.Reducer.sum is applied at the nominal scale
+  of the image to each geometry in the fc, and the total area in meters squared
+  is calculated by summing all feautes in the collection."""
+  im = image.multiply(ee.Image.pixelArea())
+  ns = image.projection().nominalScale()
+  scale = ee.Algorithms.If(scale, scale, ns)
+  bn = im.bandNames().get(0)
+  def get_reduce_regions(fc):
+      res = im.reduceRegions( \
+          reducer = ee.Reducer.sum().unweighted(),\
+          collection = ee.FeatureCollection(fc), \
+          scale = scale, \
+          tileScale = 1) \
+      .aggregate_sum('sum')
+      return ee.FeatureCollection(ee.Feature(None, {'area_m2': res}))
+  def get_reduce_map(f):
+      res = im.reduceRegion( \
+          reducer = ee.Reducer.sum().unweighted(),\
+          geometry = f.geometry(), \
+          scale = scale, \
+          bestEffort = bestEffort, \
+          maxPixels = 1e8, \
+          tileScale = 1) \
+      .get(bn)
+      return ee.Feature(None, {'area_m2': res})  
+  def get_sample(f):
+      fc = image.sample(
+          region = f.geometry(), \
+          numPixels = numPixels, \
+          scale = scale, \
+          tileScale = 1, \
+          dropNulls = False)
+      tc =  fc.filterMetadata(bn, 'equals', 1).aggregate_count(bn)
+      tnc =  fc.size()
+      area = f.geometry().area(1)
+      res = ee.Number(tc).divide(tnc).multiply(area)
+      return ee.Feature(None, {'total_px':tnc, 'yes_px':tc, 'geom_area_m2':area, 'area_m2': res})  
+  out = ee.Dictionary({ \
+                 'reduce_regions': get_reduce_regions(fc),
+                 'reduce_region_map': ee.FeatureCollection(fc).map(get_reduce_map),
+                 'sample_region_map': ee.FeatureCollection(fc).map(get_sample)     
+  })
+  return ee.Number(ee.FeatureCollection(out.get(method)).aggregate_sum('area_m2'))
+
+def reduce_extent_fc(image, fc, bestEffort=False, scale=False):
+  """ Given an ee.featureCollection (fc) of features each with
+  a single geometry calculate the total extent (area_m2) using
+  a single band binary image. The single band binary image is 
+  multiplied by pixel area, ee.Reducer.sum is applied at the nominal scale
+  of the image to each geometry in the fc, and the total area in meters squared
+  is calculated by summing all feautes in the collection."""
+  im = image.multiply(ee.Image.pixelArea())
+  ns = image.projection().nominalScale()
+  scale = ee.Algorithms.If(scale, scale, ns)
+  bn = im.bandNames().get(0)
+  def get_reduce(f):
+      res = im.reduceRegion( \
+          reducer = ee.Reducer.sum().unweighted(),\
+          geometry = f.geometry(), \
+          scale = scale, \
+          bestEffort = bestEffort, \
+          maxPixels = 1e12, \
+          tileScale = 4) \
+      .get(bn)
+      return ee.Feature(None, {'area_m2': res})
+  fcc = ee.FeatureCollection(fc).map(get_reduce)  
+  return ee.Number(fcc.aggregate_sum('area_m2'))
+                             
+def sample_extent_fc(image, fc, numPixels = 5000, scale=False):
+  """ Given an ee.featureCollection (fc) of features each with
+  a single geometry calculate the total extent (area_m2) using
+  a single band binary image. The single band binary image is 
+  sampled at the nominal scale of the image to each geometry in the fc
+  , the proportion of 1s in the geometry is calculated, and the total area in meters squared
+  is calculated by summing all feautes in the collection."""
+  numPixels = ee.Number(numPixels)
+  ns = image.projection().nominalScale()
+  scale = ee.Algorithms.If(scale, scale, ns)
+  bn = image.bandNames().get(0)
+  def get_sample(f):
+      fc = image.sample(
+          region = f.geometry(), \
+          numPixels = numPixels, \
+          scale = scale, \
+          tileScale = 4, \
+          dropNulls = True)
+      tc =  fc.filterMetadata(bn, 'equals', 1).aggregate_count(bn)
+      area = f.geometry().area(1)
+      res = ee.Number(tc).divide(numPixels).multiply(area)
+      return ee.Feature(None, {'total_px':numPixels, 'yes_px':tc, 'geom_area_m2':area, 'area_m2': res})
+  fcc = ee.FeatureCollection(fc).map(get_sample)
+  return ee.Number(fcc.aggregate_sum('area_m2'))
+
+def sample_statistics(image, geom, numPixels, scale):
+  """ Sample within a region of a single band float image,
+  returning a dictionary of statistics:
+  accessed as ["values"]["<stat>"]
+  Note this is an estimate"""
+  bn = image.bandNames().getInfo()[0]
+  fc = image.sample(region=geom, numPixels = numPixels, scale= scale, tileScale= 16, dropNulls=True)
+  return fc.aggregate_stats(bn)
+
+def divide_geometry(feature):
+    """ Divide feature geometry
+    *
+    * Split a features polygon geometry in 4 using its' center point
+    * 
+    * @param {ee.Feature} A feature with a polygon geometry to split.
+    * 
+    * @return {ee.FeatureCollection} Collection with 4 features per input feature.
+    * 
+    * @example aoi = Map.getBounds() fc = divideGeometry(aoi)
+    """
+    # Get coordinates of polygons bounds
+    g = feature.geometry()
+    l2 = g.bounds(1).coordinates().flatten()
+    c2 = g.centroid(1).coordinates().flatten()
+    # Create 4 cells dividing bounds at mid point
+    t0 = ee.Feature(ee.Geometry.Polygon( \
+    [l2.get(0), l2.get(1), \
+    c2.get(0), l2.get(1), \
+    c2.get(0), c2.get(1), \
+    l2.get(0), c2.get(1), \
+    l2.get(0), l2.get(1), \
+    ]), {"name": "t0"})
+    t1 = ee.Feature(ee.Geometry.Polygon( \
+    [c2.get(0), l2.get(3), \
+    l2.get(2), l2.get(3), \
+    l2.get(2), c2.get(1), \
+    c2.get(0), c2.get(1), \
+    c2.get(0), l2.get(3), \
+    ]), {"name": "t1"})
+    t2 = ee.Feature(ee.Geometry.Polygon( \
+    [c2.get(0), c2.get(1), \
+    l2.get(4), c2.get(1), \
+    l2.get(4), l2.get(5), \
+    c2.get(0), l2.get(5), \
+    c2.get(0), c2.get(1), \
+    ]), {"name": "t2"})
+    t3 = ee.Feature(ee.Geometry.Polygon( \
+    [l2.get(0), c2.get(1), \
+    c2.get(0), c2.get(1), \
+    c2.get(0), l2.get(7), \
+    l2.get(6), l2.get(7), \
+    l2.get(0), c2.get(1), \
+    ]), {"name": "t3"})
+    # Make a featureCollection
+    fc = ee.FeatureCollection([t0,t1,t2,t3,])
+    # Map intersection with feature and return cell name
+    def tmp_f(f): 
+        return ee.Feature( \
+        feature.geometry().intersection(f.geometry(),1) \
+        , {"name": f.get("name")})
+    return ee.FeatureCollection(fc.map(tmp_f))
+    
+def ee_squaremeters_to_ha(value):
+    """Converts square meters to hectares, and gives val to 2 decimal places"""
+    tmp = ee.Number(value).divide(10000)
+    tmp1 = ee.Number(ee.Number(tmp).format('%.2f'))
+    return ee.Number.parse(tmp1)
+
 def get_geocode(point):
     result = geocoder.osm(point, method='reverse', lang_code='en')
     if 'ERROR' in str(result): result = None
@@ -286,3 +451,4 @@ def admin_1_simplify(iso, admin1):
         simplification = admin_1_dic.get(iso, None).get(admin1, None)
         logging.info(f'[admin_1_simplify]: {simplification}')
     return simplification
+


### PR DESCRIPTION
NOTE this has not been tested locally due to issues on my instance!

for example of testing and validation against GFW tables see:
https://colab.research.google.com/drive/1LEvjMnkrfbSaHAKZvge5TeLGf3h0I-Ol

Major update to gee-analysis umd-loss-gain service:

+ refactored gee code to be SERVER-SIDE
+ reduced number of assets used
+ rebuilt gee asset to be optimised for this analysis
+ added improved documentation, yeah!
+ refactored internal function variable names to make things clearer
+ implemented option to spit geometries (4,16,64,256) times
+ implemented 3 options of variations on the zonal count analysis; reduce_regions, map_reduce_region, and map_sample_region
+ bestEffort option can now be used on correctly pyramided raster assets using the map_reduce_region option