### PR TITLE
Swap to tile fetcher key in getMapId

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ pip install -r requirements_dev.txt  --use-feature=2020-resolver
 pytest --cov=gfwanalysis gfwanalysis/tests/
 ```
 
+Testing requires a local Redis instance running with a `REDIS_URL` environment variable.
+
 ### Code structure
 
 The API has been packed in a Python module (gfwanalysis). It creates and exposes a WSGI application. The core functionality

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ Run the tests via docker with:
 ./gfwanalysis.sh test
 ```
 
-Or nativley via:
+Or natively via:
 ```ssh
-pip install -r requirements.txt
+pip install -r requirements.txt  --use-feature=2020-resolver
+pip install -r requirements_dev.txt  --use-feature=2020-resolver
 pytest --cov=gfwanalysis gfwanalysis/tests/
 ```
 

--- a/gfwanalysis/serializers.py
+++ b/gfwanalysis/serializers.py
@@ -322,7 +322,7 @@ def serialize_highres_url(analysis, type):
 
 
 def serialize_recent_data(analysis, type):
-    logging.info("[SERIALISER] initiating...")
+    logging.info("[SERIALIZER] initiating...")
     """Convert output of images to json"""
     output = []
 

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -98,7 +98,6 @@ class RecentTiles(object):
         for response in await asyncio.gather(*futures):
             pass
 
-        return_results = []
         for f in range(0, len(futures)):
             data_array[f] = futures[f].result()
 
@@ -111,20 +110,26 @@ class RecentTiles(object):
         logging.info(f"[RECENT>TILE] {col_data.get('source')}")
 
         validated_bands = ["B4", "B3", "B2"]
-        if bands: validated_bands = RecentTiles.validate_bands(bands, col_data.get('source'))
-        if not bmin: bmin = 0
+        if bands:
+            validated_bands = RecentTiles.validate_bands(bands, col_data.get('source'))
+        if not bmin:
+            bmin = 0
 
         if 'COPERNICUS' in col_data.get('source'):
-            if not bmax: bmax = 0.3
+            if not bmax:
+                bmax = 0.3
             im = ee.Image(col_data['source']).divide(10000).visualize(bands=validated_bands, min=bmin, max=bmax,
                                                                       opacity=opacity)
         elif 'LANDSAT' in col_data.get('source'):
-            if not bmax: bmax = 0.2
+            if not bmax:
+                bmax = 0.2
             tmp_im = ee.Image(col_data['source'])
             im = RecentTiles.pansharpened_L8_image(tmp_im, validated_bands, bmin, bmax, opacity)
 
         m_id = im.getMapId()
-        url = m_id['tile_fetcher'].url_format
+        # url = m_id['tile_fetcher'].url_format
+        base_url = 'https://earthengine.googleapis.com'
+        url = (base_url + '/map/' + m_id['mapid'] + '/{z}/{x}/{y}?token=' + m_id['token'])
 
         col_data['tile_url'] = url
         logging.info(f'[RECENT>TILE] Tile url retrieved: {url}.')
@@ -141,12 +146,14 @@ class RecentTiles(object):
         if not bmin: bmin = 0
 
         if 'COPERNICUS' in col_data.get('source'):
-            if not bmax: bmax = 0.3
+            if not bmax:
+                bmax = 0.3
             im = ee.Image(col_data['source']).divide(10000).visualize(bands=validated_bands, min=bmin, max=bmax,
                                                                       opacity=opacity)
 
         elif 'LANDSAT' in col_data.get('source'):
-            if not bmax: bmax = 0.2
+            if not bmax:
+                bmax = 0.2
             tmp_im = ee.Image(col_data['source'])
             im = RecentTiles.pansharpened_L8_image(tmp_im, validated_bands, bmin, bmax, opacity)
 

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -127,9 +127,7 @@ class RecentTiles(object):
             im = RecentTiles.pansharpened_L8_image(tmp_im, validated_bands, bmin, bmax, opacity)
 
         m_id = im.getMapId()
-        # url = m_id['tile_fetcher'].url_format
-        base_url = 'https://earthengine.googleapis.com'
-        url = (base_url + '/map/' + m_id['mapid'] + '/{z}/{x}/{y}?token=' + m_id['token'])
+        url = m_id['tile_fetcher'].url_format
 
         col_data['tile_url'] = url
         logging.info(f'[RECENT>TILE] Tile url retrieved: {url}.')

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -124,9 +124,7 @@ class RecentTiles(object):
             im = RecentTiles.pansharpened_L8_image(tmp_im, validated_bands, bmin, bmax, opacity)
 
         m_id = im.getMapId()
-
-        base_url = 'https://earthengine.googleapis.com'
-        url = (base_url + '/map/' + m_id['mapid'] + '/{z}/{x}/{y}?token=' + m_id['token'])
+        url = m_id['tile_fetcher'].url_format
 
         col_data['tile_url'] = url
         logging.info(f'[RECENT>TILE] Tile url retrieved: {url}.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ geocoder==1.38.1
 google-cloud==0.34.0
 googletrans==2.4.0
 numpy==1.17.2
-oauth2client==4.1.3
+oauth2client==3.0.0
 pandas==0.25.3
 pycrypto==2.6.1
 pyproj==1.9.6

--- a/tests/recent_tiles_tests.py
+++ b/tests/recent_tiles_tests.py
@@ -1,10 +1,10 @@
-from gfwanalysis.serializers import serialize_recent_url, serialize_recent_data
+from gfwanalysis.serializers import serialize_recent_data
 from gfwanalysis.services.analysis.recent_tiles import RecentTiles
 
 
-def test_serialize_recent_tiles_data():
+def test_serialize_recent_data():
     """Test the Recent Tiles data Serializer."""
-    d = [{
+    response_data = [{
         'spacecraft': 'a1',
         'source': 'a2',
         'cloud_score': 'a3',
@@ -23,25 +23,23 @@ def test_serialize_recent_tiles_data():
     }]
 
     id_type = 'recent_tiles_data'
-    s_obj = serialize_recent_data(d, id_type)
-    assert s_obj.get('type') == id_type
-    assert len(s_obj.get('tiles', [])) == 2
-    assert s_obj.get('tiles')[0].get('attributes').get(
-        'instrument') == d[0]['spacecraft']
-    assert s_obj.get('tiles')[0].get(
-        'attributes').get('source') == d[0]['source']
-    assert s_obj.get('tiles')[0].get('attributes').get(
-        'cloud_score') == d[0]['cloud_score']
-    assert s_obj.get('tiles')[0].get(
-        'attributes').get('date_time') == d[0]['date']
-    assert s_obj.get('tiles')[0].get('attributes').get(
-        'tile_url') == d[0]['tile_url']
-    assert s_obj.get('tiles')[0].get('attributes').get('bbox') == d[0]['bbox']
-    assert s_obj.get('tiles')[0].get('attributes').get(
-        'thumbnail_url') == d[0]['thumb_url']
+    serialized_object = serialize_recent_data(response_data, id_type)
+
+    assert serialized_object.get('type') == id_type
+    assert len(serialized_object.get('tiles', [])) == 2
+
+    serialized_object_attribute = serialized_object.get('tiles')[0].get('attributes')
+
+    assert serialized_object_attribute.get('instrument') == response_data[0]['spacecraft']
+    assert serialized_object_attribute.get('source') == response_data[0]['source']
+    assert serialized_object_attribute.get('cloud_score') == response_data[0]['cloud_score']
+    assert serialized_object_attribute.get('date_time') == response_data[0]['date']
+    assert serialized_object_attribute.get('tile_url') == response_data[0]['tile_url']
+    assert serialized_object_attribute.get('bbox') == response_data[0]['bbox']
+    assert serialized_object_attribute.get('thumbnail_url') == response_data[0]['thumb_url']
 
 
-def test_recent_tile_data_type():
+def test_recent_data_type():
     """
     Test a known region gives back expected types.
     """
@@ -56,12 +54,16 @@ def test_recent_tile_data_type():
     kwargs = {'lat': lat, 'lon': lon,
               'start': start, 'end': end, 'sort_by': None}
     method_response = RecentTiles.recent_data(**kwargs)
+    first_tile = method_response[0]
 
-    spacecraft = ['COPERNICUS', 'LANDSAT']
+    spacecraft_list = ['Sentinel', 'Landsat']
+
     assert len(method_response) > 1
-    assert type(method_response[0].get('bbox')) == dict
-    assert type(method_response[0].get('source')) == str
-    assert 0 <= method_response[0].get('cloud_score') <= 100
-    assert type(method_response[0].get('spacecraft')) == str
-    assert any([s in method_response[0].get('spacecraft') for s in spacecraft])
-    assert type(method_response[0].get('date')) == str
+    assert type(first_tile.get('bbox')) == dict
+    assert type(first_tile.get('source')) == str
+    assert 0 <= first_tile.get('cloud_score') <= 100
+    assert type(first_tile.get('spacecraft')) == str
+    assert any([spacecraft in first_tile.get('spacecraft') for spacecraft in spacecraft_list])
+    assert type(first_tile.get('date')) == str
+
+

--- a/tests/recent_tiles_tests.py
+++ b/tests/recent_tiles_tests.py
@@ -1,0 +1,67 @@
+from gfwanalysis.serializers import serialize_recent_url, serialize_recent_data
+from gfwanalysis.services.analysis.recent_tiles import RecentTiles
+
+
+def test_serialize_recent_tiles_data():
+    """Test the Recent Tiles data Serializer."""
+    d = [{
+        'spacecraft': 'a1',
+        'source': 'a2',
+        'cloud_score': 'a3',
+        'date': 'a4',
+        'tile_url': 'a5',
+        'thumb_url': 'a6',
+        'bbox': 'a7'
+    }, {
+        'spacecraft': 'b1',
+        'source': 'b2',
+        'cloud_score': 'b3',
+        'date': 'b4',
+        'tile_url': 'b5',
+        'thumb_url': 'b6',
+        'bbox': 'b7'
+    }]
+
+    id_type = 'recent_tiles_data'
+    s_obj = serialize_recent_data(d, id_type)
+    assert s_obj.get('type') == id_type
+    assert len(s_obj.get('tiles', [])) == 2
+    assert s_obj.get('tiles')[0].get('attributes').get(
+        'instrument') == d[0]['spacecraft']
+    assert s_obj.get('tiles')[0].get(
+        'attributes').get('source') == d[0]['source']
+    assert s_obj.get('tiles')[0].get('attributes').get(
+        'cloud_score') == d[0]['cloud_score']
+    assert s_obj.get('tiles')[0].get(
+        'attributes').get('date_time') == d[0]['date']
+    assert s_obj.get('tiles')[0].get('attributes').get(
+        'tile_url') == d[0]['tile_url']
+    assert s_obj.get('tiles')[0].get('attributes').get('bbox') == d[0]['bbox']
+    assert s_obj.get('tiles')[0].get('attributes').get(
+        'thumbnail_url') == d[0]['thumb_url']
+
+
+def test_recent_tile_data_type():
+    """
+    Test a known region gives back expected types.
+    """
+
+    # Canaries Test
+    lon = -16.644
+    lat = 28.266
+
+    start = '2020-01-01'
+    end = '2020-02-01'
+
+    kwargs = {'lat': lat, 'lon': lon,
+              'start': start, 'end': end, 'sort_by': None}
+    method_response = RecentTiles.recent_data(**kwargs)
+
+    spacecraft = ['COPERNICUS', 'LANDSAT']
+    assert len(method_response) > 1
+    assert type(method_response[0].get('bbox')) == dict
+    assert type(method_response[0].get('source')) == str
+    assert 0 <= method_response[0].get('cloud_score') <= 100
+    assert type(method_response[0].get('spacecraft')) == str
+    assert any([s in method_response[0].get('spacecraft') for s in spacecraft])
+    assert type(method_response[0].get('date')) == str

--- a/tests/recent_tiles_tests.py
+++ b/tests/recent_tiles_tests.py
@@ -41,7 +41,7 @@ def test_serialize_recent_data():
 
 def test_recent_data_type():
     """
-    Test a known region gives back expected types.
+    Test a known lat, lon iniput gives back expected metadata response.
     """
 
     # Canaries Test
@@ -67,3 +67,26 @@ def test_recent_data_type():
     assert type(first_tile.get('date')) == str
 
 
+def test_recent_tile_url():
+    """
+    Test a known source returns expected tile url.
+    """
+
+    col_data = {'source': 'COPERNICUS/S2/20200530T115219_20200530T115220_T28RCS'}
+
+    kwargs = {  
+        'col_data': col_data,
+        'bands':None,
+        'bmin':None,
+        'bmax':None,
+        'opacity':None
+    }
+
+    method_response = RecentTiles.recent_tiles(**kwargs)
+    tile_url = method_response.get('tile_url', '')
+    source = method_response.get('source', '')
+    
+    assert 'source' in method_response
+    assert source in col_data['source']
+    assert 'tile_url' in method_response
+    assert 'https://earthengine.googleapis.com/v1alpha/projects/earthengine-legacy/maps/' in tile_url


### PR DESCRIPTION
Swaps url construction method using `getMapid` in  `/recent-tiles/tiles` endpoint.

Expected tile url format is now returned directly from `tile_fetcher.url_format`.