### PR TITLE
Increase size of tile list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # 1.0.0
 
+## 12/11/2020
+
+- Updated recent-tiles service to assure correct number of images returned.
+  
 ## 15/06/2020
 
-- Updated WHRC-biomass service to improve accuracy of density calculation
+- Updated WHRC-biomass service to improve accuracy of density calculation.
 
 ## 09/04/2020
 

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -127,9 +127,7 @@ class RecentTiles(object):
             im = RecentTiles.pansharpened_L8_image(tmp_im, validated_bands, bmin, bmax, opacity)
 
         m_id = im.getMapId()
-        # url = m_id['tile_fetcher'].url_format
-        base_url = 'https://earthengine.googleapis.com'
-        url = (base_url + '/map/' + m_id['mapid'] + '/{z}/{x}/{y}?token=' + m_id['token'])
+        url = m_id['tile_fetcher'].url_format
 
         col_data['tile_url'] = url
         logging.info(f'[RECENT>TILE] Tile url retrieved: {url}.')

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -127,7 +127,9 @@ class RecentTiles(object):
             im = RecentTiles.pansharpened_L8_image(tmp_im, validated_bands, bmin, bmax, opacity)
 
         m_id = im.getMapId()
-        url = m_id['tile_fetcher'].url_format
+        # url = m_id['tile_fetcher'].url_format
+        base_url = 'https://earthengine.googleapis.com'
+        url = (base_url + '/map/' + m_id['mapid'] + '/{z}/{x}/{y}?token=' + m_id['token'])
 
         col_data['tile_url'] = url
         logging.info(f'[RECENT>TILE] Tile url retrieved: {url}.')

--- a/gfwanalysis/services/analysis/recent_tiles.py
+++ b/gfwanalysis/services/analysis/recent_tiles.py
@@ -168,7 +168,12 @@ class RecentTiles(object):
             point = ee.Geometry.Point(float(lon), float(lat))
             S2 = ee.ImageCollection('COPERNICUS/S2').filterDate(start, end).filterBounds(point)
             L8 = ee.ImageCollection('LANDSAT/LC08/C01/T1_RT_TOA').filterDate(start, end).filterBounds(point)
-            collection = S2.toList(52).cat(L8.toList(52)).getInfo()
+
+            s2_size = S2.size().getInfo()
+            l8_size = S2.size().getInfo()
+
+            collection = S2.toList(s2_size).cat(L8.toList(l8_size)).getInfo()
+                        
             data = []
             for c in collection:
                 sentinel_image = c.get('properties').get('SPACECRAFT_NAME', None)

--- a/tests/recent_tiles_tests.py
+++ b/tests/recent_tiles_tests.py
@@ -1,6 +1,7 @@
 from gfwanalysis.serializers import serialize_recent_data
 from gfwanalysis.services.analysis.recent_tiles import RecentTiles
 
+import ee
 
 def test_serialize_recent_data():
     """Test the Recent Tiles data Serializer."""
@@ -51,8 +52,14 @@ def test_recent_data_type():
     start = '2020-01-01'
     end = '2020-02-01'
 
-    kwargs = {'lat': lat, 'lon': lon,
-              'start': start, 'end': end, 'sort_by': None}
+    kwargs = {
+        'lat': lat,
+        'lon': lon,
+        'start': start,
+        'end': end,
+        'sort_by': None
+    }
+    
     method_response = RecentTiles.recent_data(**kwargs)
     first_tile = method_response[0]
 
@@ -74,7 +81,7 @@ def test_recent_tile_url():
 
     col_data = {'source': 'COPERNICUS/S2/20200530T115219_20200530T115220_T28RCS'}
 
-    kwargs = {  
+    kwargs = {
         'col_data': col_data,
         'bands':None,
         'bmin':None,
@@ -90,3 +97,25 @@ def test_recent_tile_url():
     assert source in col_data['source']
     assert 'tile_url' in method_response
     assert 'https://earthengine.googleapis.com/v1alpha/projects/earthengine-legacy/maps/' in tile_url
+
+
+def test_asset_number():
+    """
+    Test a known source returns expected number of tile urls.
+    """
+
+    kwargs = {
+        'lat': -9.23750030205276,
+        'lon': -49.0543414324293,
+        'start': '2019-01-02',
+        'end': '2020-01-01',
+        'sort_by': None
+    }
+
+    point = ee.Geometry.Point(float(kwargs['lon']), float(kwargs['lat']))
+    s2_size = ee.ImageCollection('COPERNICUS/S2').filterDate(kwargs['start'], kwargs['end']).filterBounds(point).size()
+    l8_size = ee.ImageCollection('LANDSAT/LC08/C01/T1_RT_TOA').filterDate(kwargs['start'], kwargs['end']).filterBounds(point).size()
+    expected_size = s2_size.getInfo() + l8_size.getInfo()
+
+    tiles_data = RecentTiles.recent_data(**kwargs)
+    assert len(tiles_data) == expected_size

--- a/tests/recent_tiles_tests.py
+++ b/tests/recent_tiles_tests.py
@@ -3,6 +3,7 @@ from gfwanalysis.services.analysis.recent_tiles import RecentTiles
 
 import ee
 
+
 def test_serialize_recent_data():
     """Test the Recent Tiles data Serializer."""
     response_data = [{
@@ -59,7 +60,7 @@ def test_recent_data_type():
         'end': end,
         'sort_by': None
     }
-    
+
     method_response = RecentTiles.recent_data(**kwargs)
     first_tile = method_response[0]
 
@@ -83,16 +84,16 @@ def test_recent_tile_url():
 
     kwargs = {
         'col_data': col_data,
-        'bands':None,
-        'bmin':None,
-        'bmax':None,
-        'opacity':None
+        'bands': None,
+        'bmin': None,
+        'bmax': None,
+        'opacity': None
     }
 
     method_response = RecentTiles.recent_tiles(**kwargs)
     tile_url = method_response.get('tile_url', '')
     source = method_response.get('source', '')
-    
+
     assert 'source' in method_response
     assert source in col_data['source']
     assert 'tile_url' in method_response
@@ -114,7 +115,8 @@ def test_asset_number():
 
     point = ee.Geometry.Point(float(kwargs['lon']), float(kwargs['lat']))
     s2_size = ee.ImageCollection('COPERNICUS/S2').filterDate(kwargs['start'], kwargs['end']).filterBounds(point).size()
-    l8_size = ee.ImageCollection('LANDSAT/LC08/C01/T1_RT_TOA').filterDate(kwargs['start'], kwargs['end']).filterBounds(point).size()
+    l8_size = ee.ImageCollection('LANDSAT/LC08/C01/T1_RT_TOA').filterDate(kwargs['start'], kwargs['end']).filterBounds(
+        point).size()
     expected_size = s2_size.getInfo() + l8_size.getInfo()
 
     tiles_data = RecentTiles.recent_data(**kwargs)


### PR DESCRIPTION
## Overview

Grabs the size of the S2 and L8 feature collections before converting using `toList()` and concatenating so that the list does not drop any images when `.getInfo()` is called. 

Also removes a line of unused code.